### PR TITLE
Refactored SegmentLookup

### DIFF
--- a/src/org/vitrivr/cineast/api/JSONAPIThread.java
+++ b/src/org/vitrivr/cineast/api/JSONAPIThread.java
@@ -90,7 +90,7 @@ public class JSONAPIThread extends Thread {
 				String shotId = queryObject.get("shotid").asString();
 
 				SegmentLookup sl = new SegmentLookup();
-				SegmentDescriptor shot = sl.lookUpSegment(shotId);
+				SegmentDescriptor shot = sl.lookUpSegment(shotId).get();
 				//List<ShotDescriptor> allShots = sl.lookUpVideo(shot.getObjectId());
 
 				//Send metadata
@@ -117,7 +117,7 @@ public class JSONAPIThread extends Thread {
 					String shotId = clientJSON.get("shotid").asString();
 
 					SegmentLookup sl = new SegmentLookup();
-					SegmentDescriptor shot = sl.lookUpSegment(shotId);
+					SegmentDescriptor shot = sl.lookUpSegment(shotId).get();
 
 					JsonObject resultobj = new JsonObject();
 					resultobj.add("type", "submitShot").add("videoId", shot.getObjectId()).add("start", shot.getStart()).add("end", shot.getEnd());
@@ -364,13 +364,13 @@ public class JSONAPIThread extends Thread {
 				  
 					JsonValue val = shotidlist.get(i);
 					String shotid = val.asString();
-					SegmentDescriptor descriptor = sl.lookUpSegment(shotid);
+					SegmentDescriptor descriptor = sl.lookUpSegment(shotid).get();
 					
 					String video = descriptor.getObjectId();
 					int startSegment = Math.max(1, descriptor.getSequenceNumber() - limit);
 					int endSegment = descriptor.getSequenceNumber() + limit;
 					
-					List<SegmentDescriptor> all = sl.lookUpAllSegments(video);
+					List<SegmentDescriptor> all = sl.lookUpSegmentsOfObject(video);
 
 					for(SegmentDescriptor sd : all){
 					  if(sd.getSequenceNumber() >= startSegment && sd.getSequenceNumber() <= endSegment){
@@ -425,7 +425,7 @@ public class JSONAPIThread extends Thread {
 
 			case "getSegments":{
 				String multimediaobjectId = clientJSON.get("multimediaobjectId").asString();
-				List<SegmentDescriptor> segments = new SegmentLookup().lookUpAllSegments(multimediaobjectId);
+				List<SegmentDescriptor> segments = new SegmentLookup().lookUpSegmentsOfObject(multimediaobjectId);
 				Collections.sort(segments, new SegmentDescriptorComparator());
 
 				JsonArray list = new JsonArray();

--- a/src/org/vitrivr/cineast/api/JSONUtils.java
+++ b/src/org/vitrivr/cineast/api/JSONUtils.java
@@ -185,7 +185,7 @@ public class JSONUtils {
 			ids[i++] = sdp.key;
 		}
 		
-		Map<String, SegmentDescriptor> map = sl.lookUpSegments(ids);
+		Map<String, SegmentDescriptor> map = sl.lookUpSegments(Arrays.asList(ids));
 		
 		for(String id : ids){
 			SegmentDescriptor sd = map.get(id);
@@ -222,7 +222,7 @@ public class JSONUtils {
 			ids[i++] = sdp.key;
 		}
 		
-		Map<String, SegmentDescriptor> map = sl.lookUpSegments(ids);
+		Map<String, SegmentDescriptor> map = sl.lookUpSegments(Arrays.asList(ids));
 		
 		HashSet<String> videoIds = new HashSet<>();
 		for(String id : ids){

--- a/src/org/vitrivr/cineast/api/websocket/handlers/QueryMessageHandler.java
+++ b/src/org/vitrivr/cineast/api/websocket/handlers/QueryMessageHandler.java
@@ -1,6 +1,7 @@
 package org.vitrivr.cineast.api.websocket.handlers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -132,7 +133,7 @@ public class QueryMessageHandler extends StatelessWebsocketMessageHandler<Query>
             ids[i++] = sdp.key;
         }
 
-        Map<String, SegmentDescriptor> map = sl.lookUpSegments(ids);
+        Map<String, SegmentDescriptor> map = sl.lookUpSegments(Arrays.asList(ids));
 
         for(String id : ids){
             SegmentDescriptor sd = map.get(id);
@@ -159,7 +160,7 @@ public class QueryMessageHandler extends StatelessWebsocketMessageHandler<Query>
             ids[i++] = sdp.key;
         }
 
-        Map<String, SegmentDescriptor> map = sl.lookUpSegments(ids);
+        Map<String, SegmentDescriptor> map = sl.lookUpSegments(Arrays.asList(ids));
 
         HashSet<String> videoIds = new HashSet<>();
         for(String id : ids){

--- a/src/org/vitrivr/cineast/art/modules/VisualizationAverageColorStripeVariable.java
+++ b/src/org/vitrivr/cineast/art/modules/VisualizationAverageColorStripeVariable.java
@@ -72,7 +72,7 @@ public class VisualizationAverageColorStripeVariable extends AbstractVisualizati
   @Override
   public String visualizeMultipleSegments(List<String> segmentIds){
     SegmentLookup segmentLookup = new SegmentLookup();
-    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds.toArray(new String[segmentIds.size()]));
+    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds);
     List<SegmentDescriptor> segments = new ArrayList<>();
     for (Map.Entry<String, SegmentDescriptor> entry : segmentMap.entrySet()) {
       segments.add(entry.getValue());
@@ -83,7 +83,7 @@ public class VisualizationAverageColorStripeVariable extends AbstractVisualizati
   @Override
   public String visualizeMultimediaobject(String multimediaobjectId) {
     SegmentLookup segmentLookup = new SegmentLookup();
-    List<SegmentDescriptor> segments = segmentLookup.lookUpAllSegments(multimediaobjectId);
+    List<SegmentDescriptor> segments = segmentLookup.lookUpSegmentsOfObject(multimediaobjectId);
     return visualizeMulti(ArtUtil.getFeatureData(selectors.get("AverageColor"), multimediaobjectId), segments);
   }
 

--- a/src/org/vitrivr/cineast/art/modules/VisualizationDominantColorStripeVariable.java
+++ b/src/org/vitrivr/cineast/art/modules/VisualizationDominantColorStripeVariable.java
@@ -72,7 +72,7 @@ public class VisualizationDominantColorStripeVariable extends AbstractVisualizat
   @Override
   public String visualizeMultipleSegments(List<String> segmentIds){
     SegmentLookup segmentLookup = new SegmentLookup();
-    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds.toArray(new String[segmentIds.size()]));
+    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds);
     List<SegmentDescriptor> segments = new ArrayList<>();
     for (Map.Entry<String, SegmentDescriptor> entry : segmentMap.entrySet()) {
       segments.add(entry.getValue());
@@ -83,7 +83,7 @@ public class VisualizationDominantColorStripeVariable extends AbstractVisualizat
   @Override
   public String visualizeMultimediaobject(String multimediaobjectId) {
     SegmentLookup segmentLookup = new SegmentLookup();
-    List<SegmentDescriptor> segments = segmentLookup.lookUpAllSegments(multimediaobjectId);
+    List<SegmentDescriptor> segments = segmentLookup.lookUpSegmentsOfObject(multimediaobjectId);
     return visualizeMulti(ArtUtil.getFeatureData(selectors.get("DominantColor"), multimediaobjectId), segments);
   }
 

--- a/src/org/vitrivr/cineast/art/modules/VisualizationMedianColorStripeVariable.java
+++ b/src/org/vitrivr/cineast/art/modules/VisualizationMedianColorStripeVariable.java
@@ -72,7 +72,7 @@ public class VisualizationMedianColorStripeVariable extends AbstractVisualizatio
   @Override
   public String visualizeMultipleSegments(List<String> segmentIds){
     SegmentLookup segmentLookup = new SegmentLookup();
-    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds.toArray(new String[segmentIds.size()]));
+    Map<String, SegmentDescriptor> segmentMap = segmentLookup.lookUpSegments(segmentIds);
     List<SegmentDescriptor> segments = new ArrayList<>();
     for (Map.Entry<String, SegmentDescriptor> entry : segmentMap.entrySet()) {
       segments.add(entry.getValue());
@@ -83,7 +83,7 @@ public class VisualizationMedianColorStripeVariable extends AbstractVisualizatio
   @Override
   public String visualizeMultimediaobject(String multimediaobjectId) {
     SegmentLookup segmentLookup = new SegmentLookup();
-    List<SegmentDescriptor> segments = segmentLookup.lookUpAllSegments(multimediaobjectId);
+    List<SegmentDescriptor> segments = segmentLookup.lookUpSegmentsOfObject(multimediaobjectId);
     return visualizeMulti(ArtUtil.getFeatureData(selectors.get("MedianColor"), multimediaobjectId), segments);
   }
 

--- a/src/org/vitrivr/cineast/core/db/dao/reader/SegmentLookup.java
+++ b/src/org/vitrivr/cineast/core/db/dao/reader/SegmentLookup.java
@@ -1,10 +1,16 @@
 package org.vitrivr.cineast.core.db.dao.reader;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import static org.vitrivr.cineast.core.data.entities.SegmentDescriptor.FIELDNAMES;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.vitrivr.cineast.core.config.Config;
 import org.vitrivr.cineast.core.data.entities.SegmentDescriptor;
 import org.vitrivr.cineast.core.data.providers.primitive.PrimitiveTypeProvider;
@@ -12,179 +18,108 @@ import org.vitrivr.cineast.core.data.providers.primitive.ProviderDataType;
 import org.vitrivr.cineast.core.db.DBSelector;
 
 public class SegmentLookup extends AbstractEntityReader {
-    /**
-     * Default constructor.
-     */
-	public SegmentLookup(){
-		this(Config.sharedConfig().getDatabase().getSelectorSupplier().get());
-	}
+  /**
+   * Default constructor.
+   */
+  public SegmentLookup() {
+    this(Config.sharedConfig().getDatabase().getSelectorSupplier().get());
+  }
 
-    /**
-     * Constructor for SegmentLookup
-     *
-     * @param selector DBSelector to use for the MultimediaMetadataReader instance.
-     */
-	public SegmentLookup(DBSelector selector) {
-	    super(selector);
-        this.selector.open(SegmentDescriptor.ENTITY);
+  /**
+   * Constructor for SegmentLookup
+   *
+   * @param dbSelector DBSelector to use for the MultimediaMetadataReader instance.
+   */
+  public SegmentLookup(DBSelector dbSelector) {
+    super(dbSelector);
+    this.selector.open(SegmentDescriptor.ENTITY);
+  }
+
+  public Optional<SegmentDescriptor> lookUpSegment(String segmentId) {
+    Stream<SegmentDescriptor> descriptors = this.lookUpSegmentsByField(FIELDNAMES[0], segmentId);
+    return descriptors.findFirst();
+  }
+
+  public Map<String, SegmentDescriptor> lookUpSegments(Iterable<String> segmentIds) {
+    Stream<SegmentDescriptor> descriptors = this.lookUpSegmentsByField(FIELDNAMES[0], segmentIds);
+    return Maps.uniqueIndex(descriptors.iterator(), SegmentDescriptor::getSegmentId);
+  }
+
+  public List<SegmentDescriptor> lookUpSegmentsOfObject(String objectId) {
+    Stream<SegmentDescriptor> descriptors = this.lookUpSegmentsByField(FIELDNAMES[1], objectId);
+    return descriptors.collect(Collectors.toList());
+  }
+
+  public ListMultimap<String, SegmentDescriptor> lookUpSegmentsOfObjects(
+      Iterable<String> objectIds) {
+    Stream<SegmentDescriptor> descriptors = this.lookUpSegmentsByField(FIELDNAMES[1], objectIds);
+    return Multimaps.index(descriptors.iterator(), SegmentDescriptor::getObjectId);
+  }
+
+  private Stream<SegmentDescriptor> lookUpSegmentsByField(String fieldName, String fieldValue) {
+    return lookUpSegmentsByField(fieldName, Collections.singletonList(fieldValue));
+  }
+
+  private Stream<SegmentDescriptor> lookUpSegmentsByField(String fieldName,
+      Iterable<String> fieldValues) {
+    List<Map<String, PrimitiveTypeProvider>> segmentsProperties = this.selector
+        .getRows(fieldName, fieldValues);
+    return segmentsProperties.stream()
+        .map(SegmentLookup::propertiesToDescriptor)
+        .filter(Optional::isPresent)
+        .map(Optional::get);
+  }
+
+  private static Optional<SegmentDescriptor> propertiesToDescriptor(
+      Map<String, PrimitiveTypeProvider> properties) {
+    Optional<String>  segmentId      = getField(properties, FIELDNAMES[0], String.class);
+    Optional<String>  objectId       = getField(properties, FIELDNAMES[1], String.class);
+    Optional<Integer> sequenceNumber = getField(properties, FIELDNAMES[2], Integer.class);
+    Optional<Integer> sequenceStart  = getField(properties, FIELDNAMES[3], Integer.class);
+    Optional<Integer> sequenceEnd    = getField(properties, FIELDNAMES[4], Integer.class);
+    Optional<Float>   absoluteStart  = getField(properties, FIELDNAMES[5], Float.class);
+    Optional<Float>   absoluteEnd    = getField(properties, FIELDNAMES[6], Float.class);
+
+    if (!segmentId.isPresent()
+        || !objectId.isPresent()
+        || !sequenceNumber.isPresent()
+        || !sequenceStart.isPresent()
+        || !sequenceEnd.isPresent()
+        || !absoluteStart.isPresent()
+        || !absoluteEnd.isPresent()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(new SegmentDescriptor(
+          objectId.get(),
+          segmentId.get(),
+          sequenceNumber.get(),
+          sequenceStart.get(),
+          sequenceEnd.get(),
+          absoluteStart.get(),
+          absoluteEnd.get())
+      );
     }
-	
-	public SegmentDescriptor lookUpSegment(String segmentId){
-		
-		List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(SegmentDescriptor.FIELDNAMES[0], segmentId);
-		
-		if(results.isEmpty()){
-			return new SegmentDescriptor();
-		}
-		
-		Map<String, PrimitiveTypeProvider> map = results.get(0);
-		
-		return mapToDescriptor(map);
-		
-	}
+  }
 
-	private SegmentDescriptor mapToDescriptor(Map<String, PrimitiveTypeProvider> map) {
-		PrimitiveTypeProvider idProvider = map.get(SegmentDescriptor.FIELDNAMES[0]);
-		PrimitiveTypeProvider mmobjidProvider = map.get(SegmentDescriptor.FIELDNAMES[1]);
-		PrimitiveTypeProvider sequenceProvider = map.get(SegmentDescriptor.FIELDNAMES[2]);
-		PrimitiveTypeProvider startProvider = map.get(SegmentDescriptor.FIELDNAMES[3]);
-		PrimitiveTypeProvider endProvider = map.get(SegmentDescriptor.FIELDNAMES[4]);
-		PrimitiveTypeProvider startabsProvider = map.get(SegmentDescriptor.FIELDNAMES[5]);
-		PrimitiveTypeProvider endabsProvider = map.get(SegmentDescriptor.FIELDNAMES[6]);
-
-
-		if(idProvider == null){
-			LOGGER.error("no id in segment");
-			return new SegmentDescriptor();
-		}
-		
-		if(idProvider.getType() != ProviderDataType.STRING){
-			LOGGER.error("invalid data type for field id in segment, expected string, got {}", idProvider.getType());
-		}
-		
-		if(mmobjidProvider == null){
-			LOGGER.error("no multimediaobject in segment");
-			return new SegmentDescriptor();
-		}
-		
-		if(mmobjidProvider.getType() != ProviderDataType.STRING){
-			LOGGER.error("invalid data type for field multimediaobject in segment, expected string, got {}", mmobjidProvider.getType());
-			return new SegmentDescriptor();
-		}
-		
-		if(sequenceProvider == null){
-			LOGGER.error("no sequencenumber in segment");
-			return new SegmentDescriptor();
-		}
-		
-		if(sequenceProvider.getType() != ProviderDataType.INT){
-			LOGGER.error("invalid data type for field sequencenumber in segment, expected int, got {}", sequenceProvider.getType());
-			return new SegmentDescriptor();
-		}
-		
-		if(startProvider == null){
-			LOGGER.error("no segmentstart in segment");
-			return new SegmentDescriptor();
-		}
-		
-		if(startProvider.getType() != ProviderDataType.INT){
-			LOGGER.error("invalid data type for field segmentstart in segment, expected int, got {}", startProvider.getType());
-			return new SegmentDescriptor();
-		}
-		
-		if(endProvider == null){
-			LOGGER.error("no segmentend in segment");
-			return new SegmentDescriptor();
-		}
-		
-		if(endProvider.getType() != ProviderDataType.INT){
-			LOGGER.error("invalid data type for field segmentend in segment, expected int, got {}", endProvider.getType());
-			return new SegmentDescriptor();
-		}
-
-		if(startabsProvider.getType() == null) {
-			LOGGER.error("No absolute startpoint found in segment.");
-			return new SegmentDescriptor();
-		}
-
-		if(startabsProvider.getType() != ProviderDataType.FLOAT){
-			LOGGER.error("Invalid data type for absolute startpoint in segment, expected float, got {}.", startabsProvider.getType());
-			return new SegmentDescriptor();
-		}
-
-		if(endabsProvider.getType() == null) {
-			LOGGER.error("No absolute endpoint found in segment.");
-			return new SegmentDescriptor();
-		}
-
-		if(endabsProvider.getType() != ProviderDataType.FLOAT){
-			LOGGER.error("Invalid data type for absolute endpoint in segment, expected float, got {}.", endabsProvider.getType());
-			return new SegmentDescriptor();
-		}
-
-		return new SegmentDescriptor(mmobjidProvider.getString(), idProvider.getString(), sequenceProvider.getInt(), startProvider.getInt(), endProvider.getInt(), startabsProvider.getFloat(), endabsProvider.getFloat());
-	}
-	
-	public Map<String, SegmentDescriptor> lookUpSegments(String...ids){
-		
-		if(ids == null || ids.length == 0){
-			return new HashMap<>();
-		}
-		
-		HashMap<String, SegmentDescriptor> _return = new HashMap<>();
-		
-		List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(SegmentDescriptor.FIELDNAMES[0], ids);
-		
-		if(results.isEmpty()){
-			return new HashMap<>();
-		}
-		
-		for(Map<String, PrimitiveTypeProvider> map : results){
-			SegmentDescriptor d = mapToDescriptor(map);
-			_return.put(d.getSegmentId(), d);
-		}
-		
-		return _return;
-	}
-	
-	public Map<String, SegmentDescriptor> lookUpSegments(Iterable<String> ids){
-	  if(ids == null){
-      return new HashMap<>();
+  private static <T> Optional<T> getField(Map<String, PrimitiveTypeProvider> properties,
+      String fieldName, Class<T> fieldClass) {
+    Optional<PrimitiveTypeProvider> provider = Optional.ofNullable(properties.get(fieldName));
+    if (!provider.isPresent()) {
+      LOGGER.error("Field {} not found in segment.", fieldName);
     }
-    
-    HashMap<String, SegmentDescriptor> _return = new HashMap<>();
-    
-    List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(SegmentDescriptor.FIELDNAMES[0], ids);
-    
-    if(results.isEmpty()){
-      return new HashMap<>();
-    }
-    
-    for(Map<String, PrimitiveTypeProvider> map : results){
-      SegmentDescriptor d = mapToDescriptor(map);
-      _return.put(d.getSegmentId(), d);
-    }
-    
-    return _return;
-	}
 
-	public List<SegmentDescriptor> lookUpAllSegments(String objectId){
-		
-		List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(SegmentDescriptor.FIELDNAMES[1], objectId);
-		
-		if(results.isEmpty()){
-			return new ArrayList<>(0);
-		}
-		
-		ArrayList<SegmentDescriptor> _return = new ArrayList<>(results.size());
-		
-		for(Map<String, PrimitiveTypeProvider> map : results){
-			SegmentDescriptor descriptor = mapToDescriptor(map);
-			if(descriptor.exists()){
-				_return.add(descriptor);
-			}
-		}
-		
-		return _return;
-	}
+    Optional<Object> object = provider
+        .map(PrimitiveTypeProvider::getObject)
+        .filter(fieldClass::isInstance);
+
+    if (!object.isPresent()) {
+      ProviderDataType givenType = provider
+          .map(PrimitiveTypeProvider::getType)
+          .orElse(ProviderDataType.UNKNOWN);
+      LOGGER.error("Invalid data type for field {} in segment, expected {}, got {}.",
+          fieldName, fieldClass.toString(), givenType);
+    }
+
+    return object.map(fieldClass::cast);
+  }
 }

--- a/src/org/vitrivr/cineast/core/features/VideoMetadata.java
+++ b/src/org/vitrivr/cineast/core/features/VideoMetadata.java
@@ -36,7 +36,7 @@ public class VideoMetadata extends SolrTextRetriever {
       String id = result.get("id").getString();
       float score = MathHelper.limit(result.get("ap_score").getFloat() / words / 10f, 0f, 1f);
      
-      List<SegmentDescriptor> segments = lookup.lookUpAllSegments(id);
+      List<SegmentDescriptor> segments = lookup.lookUpSegmentsOfObject(id);
       for(int i = 0; i < segments.size(); i += STEPSIZE){
         pairs.add(new StringDoublePair(segments.get(i).getSegmentId(), score));
       }

--- a/src/org/vitrivr/cineast/core/features/listener/RetrievalResultEvaluationExporter.java
+++ b/src/org/vitrivr/cineast/core/features/listener/RetrievalResultEvaluationExporter.java
@@ -66,7 +66,7 @@ public class RetrievalResultEvaluationExporter implements RetrievalResultListene
         writer.close();
         return;
       } else {
-        SegmentDescriptor segment = sl.lookUpSegment(task.getSegmentId());
+        SegmentDescriptor segment = sl.lookUpSegment(task.getSegmentId()).get();
         MultimediaObjectDescriptor mmobject = ol.lookUpObjectById(segment.getObjectId());
         
         String path = mmobject.getPath();
@@ -93,7 +93,7 @@ public class RetrievalResultEvaluationExporter implements RetrievalResultListene
 
         StringDoublePair sdp = iter.next();
 
-        SegmentDescriptor segment = sl.lookUpSegment(sdp.key);
+        SegmentDescriptor segment = sl.lookUpSegment(sdp.key).get();
         String objectId = segment.getObjectId();
         MultimediaObjectDescriptor mmobject = ol.lookUpObjectById(objectId);
         String path = mmobject.getPath();

--- a/src/org/vitrivr/cineast/core/run/filehandler/AbstractExtractionFileHandler.java
+++ b/src/org/vitrivr/cineast/core/run/filehandler/AbstractExtractionFileHandler.java
@@ -317,7 +317,7 @@ public abstract class AbstractExtractionFileHandler<T> implements ExtractionFile
     private boolean checkAndPersistSegment(SegmentDescriptor descriptor) {
         if (this.context.existenceCheck() != IdConfig.ExistenceCheck.NOCHECK) {
             
-            if (!this.segmentReader.lookUpSegment(descriptor.getSegmentId()).exists()) {
+            if (!this.segmentReader.lookUpSegment(descriptor.getSegmentId()).get().exists()) {
                 this.segmentWriter.write(descriptor);
                 return true;
             } else if (this.context.existenceCheck() == IdConfig.ExistenceCheck.CHECK_SKIP) {

--- a/src/org/vitrivr/cineast/core/util/ArtUtil.java
+++ b/src/org/vitrivr/cineast/core/util/ArtUtil.java
@@ -105,7 +105,7 @@ public class ArtUtil {
 
   public static List<Map<String, PrimitiveTypeProvider>> getFeatureData(DBSelector selector, String multimediaobjectId){
     SegmentLookup segmentLookup = new SegmentLookup();
-    List<SegmentDescriptor> segments = segmentLookup.lookUpAllSegments(multimediaobjectId);
+    List<SegmentDescriptor> segments = segmentLookup.lookUpSegmentsOfObject(multimediaobjectId);
     Collections.sort(segments, new SegmentDescriptorComparator());
     List<String> segmentIds = new ArrayList();
     Map<String, Integer> sequenceMapping = new HashMap();
@@ -125,7 +125,7 @@ public class ArtUtil {
   }
 
   public static List<Map<String, PrimitiveTypeProvider>> getFeatureData(DBSelector selector, List<String> segmentIds){
-    Map<String, SegmentDescriptor> segments = new SegmentLookup().lookUpSegments(segmentIds.toArray(new String[segmentIds.size()]));
+    Map<String, SegmentDescriptor> segments = new SegmentLookup().lookUpSegments(segmentIds);
     Map<String, Integer> sequenceMapping = new HashMap();
     for (SegmentDescriptor segment : segments.values()) {
       segmentIds.add(segment.getSegmentId());


### PR DESCRIPTION
Refactored SegmentLookup:
- Changed signature for sake of clarity (`lookUpAllSegments` -> `lookUpSegmentsOfObject`)
- Removed code duplication regarding lookup; introduced generalized lookup method
- Removed code duplication regarding `PrimitiveTypeProvider`
- Added new method `lookUpSegmentsOfObjects`