### PR TITLE
Cleanup regarding Metadata

### DIFF
--- a/src/org/vitrivr/cineast/api/API.java
+++ b/src/org/vitrivr/cineast/api/API.java
@@ -475,7 +475,7 @@ public class API {
               Ordering<MultimediaMetadataDescriptor> ordering =
                   Ordering.explicit(ids).onResultOf(d -> d.getObjectId());
               try (MultimediaMetadataReader r = new MultimediaMetadataReader()) {
-                List<MultimediaMetadataDescriptor> descriptors = r.lookupMultimediaMetadata(ids.toArray(new String[] {}));
+                List<MultimediaMetadataDescriptor> descriptors = r.lookupMultimediaMetadata(ids);
                 descriptors.sort(ordering);
                 descriptors.forEach(System.out::println);
               }

--- a/src/org/vitrivr/cineast/api/API.java
+++ b/src/org/vitrivr/cineast/api/API.java
@@ -475,7 +475,7 @@ public class API {
               Ordering<MultimediaMetadataDescriptor> ordering =
                   Ordering.explicit(ids).onResultOf(d -> d.getObjectId());
               try (MultimediaMetadataReader r = new MultimediaMetadataReader()) {
-                List<MultimediaMetadataDescriptor> descriptors = r.lookupMultimediaMetadata(ids);
+                List<MultimediaMetadataDescriptor> descriptors = r.lookupMultimediaMetadata(ids.toArray(new String[] {}));
                 descriptors.sort(ordering);
                 descriptors.forEach(System.out::println);
               }

--- a/src/org/vitrivr/cineast/api/API.java
+++ b/src/org/vitrivr/cineast/api/API.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.api;
 
+import com.google.common.collect.Ordering;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
@@ -13,9 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.imageio.ImageIO;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -32,8 +31,10 @@ import org.vitrivr.cineast.api.websocket.WebsocketAPI;
 import org.vitrivr.cineast.core.config.Config;
 import org.vitrivr.cineast.core.config.IngestConfig;
 import org.vitrivr.cineast.core.config.QueryConfig;
+import org.vitrivr.cineast.core.data.entities.MultimediaMetadataDescriptor;
 import org.vitrivr.cineast.core.data.m3d.Mesh;
 import org.vitrivr.cineast.core.data.score.SegmentScoreElement;
+import org.vitrivr.cineast.core.db.dao.reader.MultimediaMetadataReader;
 import org.vitrivr.cineast.core.features.codebook.CodebookGenerator;
 import org.vitrivr.cineast.core.features.listener.RetrievalResultCSVExporter;
 import org.vitrivr.cineast.core.features.retriever.RetrieverInitializer;
@@ -464,6 +465,23 @@ public class API {
                   .println("added RetrievalResultCSVExporter to ContinuousRetrievalLogic");
               break;
             }
+
+            case "metadata": {
+              if (commands.size() < 2) {
+                System.err.println("You must specify at least one object id to lookup.");
+                break;
+              }
+              List<String> ids = commands.subList(1, commands.size());
+              Ordering<MultimediaMetadataDescriptor> ordering =
+                  Ordering.explicit(ids).onResultOf(d -> d.getObjectId());
+              try (MultimediaMetadataReader r = new MultimediaMetadataReader()) {
+                List<MultimediaMetadataDescriptor> descriptors = r.lookupMultimediaMetadata(ids);
+                descriptors.sort(ordering);
+                descriptors.forEach(System.out::println);
+              }
+              break;
+            }
+
             case "exit":
             case "quit": {
               System.exit(0);

--- a/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
+++ b/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
@@ -1,13 +1,18 @@
 package org.vitrivr.cineast.core.data.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.vitrivr.cineast.core.data.ExistenceCheck;
-import org.vitrivr.cineast.core.data.providers.primitive.*;
+import org.vitrivr.cineast.core.data.providers.primitive.NothingProvider;
+import org.vitrivr.cineast.core.data.providers.primitive.PrimitiveTypeProvider;
+import org.vitrivr.cineast.core.data.providers.primitive.ProviderDataType;
+import org.vitrivr.cineast.core.data.providers.primitive.StringTypeProvider;
 import org.vitrivr.cineast.core.db.dao.reader.DatabaseLookupException;
 import org.vitrivr.cineast.core.db.dao.reader.MultimediaMetadataReader;
-
-import java.util.Map;
 
 
 /**
@@ -16,129 +21,154 @@ import java.util.Map;
  * @created 10.01.17
  */
 public class MultimediaMetadataDescriptor implements ExistenceCheck {
-    /** Name of the entity in the persistence layer. */
-    public static final String ENTITY = "cineast_metadata";
+  /** Name of the entity in the persistence layer. */
+  public static final String ENTITY = "cineast_metadata";
 
-    /** Field names in the persistence layer. */
-    public static final String[] FIELDNAMES = {"objectid", "domain", "key", "value"};
+  /** Field names in the persistence layer. */
+  public static final String[] FIELDNAMES = {"objectid", "domain", "key", "value"};
 
-    /** ID of the MultimediaObject this MultimediaMetadataDescriptor belongs to. */
-    private final String objectId;
+  /** List of supported types. */
+  private static final List<Class<?>> SUPPORTED_TYPES = ImmutableList.of(
+      Integer.class, Long.class, Float.class, Double.class, String.class);
 
-    /** String value that identifies the metadata domain (e.g. EXIF, IPTC, DC...) */
-    private final String domain;
+  /** ID of the MultimediaObject this MultimediaMetadataDescriptor belongs to. */
+  private final String objectId;
 
-    /** Key (name) of the metadata entry. Must NOT be unique for a given object. */
-    private final String key;
+  /** String value that identifies the metadata domain (e.g. EXIF, IPTC, DC...) */
+  private final String domain;
 
-    /** Value of the MetadataDescriptor. */
-    private final PrimitiveTypeProvider value;
+  /** Key (name) of the metadata entry. Must NOT be unique for a given object. */
+  private final String key;
 
-    /** Flag that indicates whether or not the MultimediaMetadataDescriptor has been stored persistently in the underlying. */
-    private final boolean exists;
+  /** Value of the MetadataDescriptor. */
+  private final PrimitiveTypeProvider value;
 
-    /**
-     * Convenience method to create a MultimediaMetadataDescriptor marked as new. The method will assign
-     * a new ID to this MultimediaObjectDescriptor.
-     *
-     * @param objectId The Path that points to the file for which a new MultimediaObjectDescriptor should be created.
-     * @param key
-     * @param value
-     * @return A new MultimediaMetadataDescriptor
-     */
-    public static MultimediaMetadataDescriptor newMultimediaMetadataDescriptor(String objectId, String domain, String key, Object value) {
-        return new MultimediaMetadataDescriptor(objectId, domain, key, value, false);
+  /**
+   * Flag that indicates whether or not the MultimediaMetadataDescriptor has been stored
+   * persistently in the underlying.
+   */
+  private final boolean exists;
+
+  /**
+   * Convenience method to create a MultimediaMetadataDescriptor marked as new. The method will
+   * assign a new ID to this MultimediaObjectDescriptor.
+   *
+   * @param objectId ID of the MultimediaObject this MultimediaMetadataDescriptor belongs to.
+   * @param domain domain that the metadata entry belongs to
+   * @param key Key (name) of the metadata entry.
+   * @param value Value of the metadata entry. Can be any type of object, but only Double, Float,
+   *              Int, Long and String are supported officially.
+   * @return A new MultimediaMetadataDescriptor
+   */
+  public static MultimediaMetadataDescriptor of(String objectId, String domain, String key,
+      @Nullable Object value) {
+    return new MultimediaMetadataDescriptor(objectId, domain, key, value, false);
+  }
+
+  /**
+   * Constructor for MultimediaMetadataDescriptor. Tries to infer the type of the provided value by
+   * means of instance of. If the value is not compatible with the default primitive types, the
+   * object's toString() method is used to get a String representation.
+   *
+   * @param objectId ID of the MultimediaObject this MultimediaMetadataDescriptor belongs to.
+   * @param domain domain that the metadata entry belongs to
+   * @param key Key (name) of the metadata entry.
+   * @param value Value of the metadata entry. Can be any type of object, but only Double, Float,
+   *              Int, Long and String are supported officially.
+   */
+  public MultimediaMetadataDescriptor(String objectId, String domain, String key,
+      @Nullable Object value, boolean exists) {
+    this.objectId = objectId;
+    this.key = key;
+    this.domain = domain;
+    this.exists = exists;
+
+    if (isSupportedValue(value)) {
+      this.value = PrimitiveTypeProvider.fromObject(value);
+    } else if (value != null) {
+      this.value = new StringTypeProvider(value.toString());
+    } else {
+      this.value = new NothingProvider();
+    }
+  }
+
+  private static boolean isSupportedValue(Object value) {
+    return SUPPORTED_TYPES.stream().anyMatch(clazz -> clazz.isInstance(value));
+  }
+
+  /**
+   * Constructor for MultimediaMetadataDescriptor which can be used to create a
+   * MultimediaMetadataDescriptor from a Map containing the fieldnames as keys and the
+   * PrimitiveTypeProviders as value. Maps like this are usually returned by DB lookup classes.
+   *
+   * @param data Map that maps the fieldnames to PrimitiveTypeProvider's.
+   * @throws DatabaseLookupException If a required field could not be mapped.
+   * @see PrimitiveTypeProvider
+   * @see MultimediaMetadataReader
+   */
+  public MultimediaMetadataDescriptor(Map<String, PrimitiveTypeProvider> data)
+      throws DatabaseLookupException {
+    if (data.get(FIELDNAMES[0]) != null
+        && data.get(FIELDNAMES[0]).getType() == ProviderDataType.STRING) {
+      this.objectId = data.get(FIELDNAMES[0]).getString();
+    } else {
+      throw new DatabaseLookupException(
+          "Could not read column '" + FIELDNAMES[0] + "' for MultimediaObjectDescriptor.");
     }
 
-    /**
-     * Constructor for MultimediaMetadataDescriptor. Tries to infer the type of the provided value by means of
-     * instance of. If the value is not compatible with the default primitive types, the object's toString() method is
-     * used to get a String representation.
-     *
-     * @param objectId ID of the MultimediaObject this MultimediaMetadataDescriptor belongs to.
-     * @param domain
-     * @param key Key (name) of the metadata entry.
-     * @param value Value of the metadata entry. Can be any type of object, but only Double, Float, Int, Long and String are supported officialy.
-     */
-    public MultimediaMetadataDescriptor(String objectId, String domain, String key, Object value, boolean exists) {
-        this.objectId = objectId;
-        this.key = key;
-        this.domain = domain;
-        if (value instanceof Float) {
-            this.value = new FloatTypeProvider((Float)value);
-        } else if (value instanceof Double) {
-            this.value = new DoubleTypeProvider((Double) value);
-        } else if (value instanceof Integer) {
-            this.value = new IntTypeProvider((Integer) value);
-        } else if (value instanceof Long) {
-            this.value = new LongTypeProvider((Long) value);
-        } else if (value instanceof String) {
-            this.value = new StringTypeProvider((String) value);
-        } else if (value != null) {
-            this.value = new StringTypeProvider(value.toString());
-        } else {
-            this.value = new NothingProvider();
-        }
-        this.exists = exists;
+    if (data.get(FIELDNAMES[1]) != null
+        && data.get(FIELDNAMES[1]).getType() == ProviderDataType.STRING) {
+      this.domain = data.get(FIELDNAMES[1]).getString();
+    } else {
+      throw new DatabaseLookupException(
+          "Could not read column '" + FIELDNAMES[1] + "' for MultimediaObjectDescriptor.");
     }
 
-    /**
-     * Constructor for MultimediaMetadataDescriptor which can be used to create a MultimediaMetadataDescriptor from a Map
-     * containing the fieldnames as keys and the PrimitiveTypeProviders as value. Maps like this are usually returned
-     * by DB lookup classes.
-     *
-     * @see PrimitiveTypeProvider
-     * @see MultimediaMetadataReader
-     *
-     * @param data Map that maps the fieldnames to PrimitiveTypeProvider's.
-     * @throws DatabaseLookupException If a required field could not be mapped.
-     */
-    public MultimediaMetadataDescriptor(Map<String, PrimitiveTypeProvider> data) throws DatabaseLookupException {
-        if (data.get(FIELDNAMES[0])!= null && data.get(FIELDNAMES[0]).getType() == ProviderDataType.STRING) {
-            this.objectId = data.get(FIELDNAMES[0]).getString();
-        } else {
-            throw new DatabaseLookupException("Could not read column '" + FIELDNAMES[0] + "' for MultimediaObjectDescriptor.");
-        }
-
-        if (data.get(FIELDNAMES[1])!= null && data.get(FIELDNAMES[1]).getType() == ProviderDataType.STRING) {
-            this.domain = data.get(FIELDNAMES[1]).getString();
-        } else {
-            throw new DatabaseLookupException("Could not read column '" + FIELDNAMES[1] + "' for MultimediaObjectDescriptor.");
-        }
-
-        if (data.get(FIELDNAMES[2])!= null && data.get(FIELDNAMES[2]).getType() == ProviderDataType.STRING) {
-            this.key = data.get(FIELDNAMES[2]).getString();
-        } else {
-            throw new DatabaseLookupException("Could not read column '" + FIELDNAMES[2] + "' for MultimediaObjectDescriptor.");
-        }
-
-        this.value = data.get(FIELDNAMES[3]);
-        this.exists = true;
-    }
-    
-    @JsonProperty
-    public String getObjectId() {
-        return objectId;
+    if (data.get(FIELDNAMES[2]) != null
+        && data.get(FIELDNAMES[2]).getType() == ProviderDataType.STRING) {
+      this.key = data.get(FIELDNAMES[2]).getString();
+    } else {
+      throw new DatabaseLookupException(
+          "Could not read column '" + FIELDNAMES[2] + "' for MultimediaObjectDescriptor.");
     }
 
-    @JsonProperty
-    public String getDomain() {
-        return domain;
-    }
+    this.value = data.get(FIELDNAMES[3]);
+    this.exists = true;
+  }
 
-    @JsonProperty
-    public String getKey() {
-        return key;
-    }
+  @JsonProperty
+  public String getObjectId() {
+    return objectId;
+  }
 
-    @JsonProperty
-    public Object getValue() {
-        return PrimitiveTypeProvider.getObject(this.value);
-    }
+  @JsonProperty
+  public String getDomain() {
+    return domain;
+  }
 
-    @Override
-    public boolean exists() {
-        return this.exists;
-    }
+  @JsonProperty
+  public String getKey() {
+    return key;
+  }
+
+  @JsonProperty
+  public Object getValue() {
+    return PrimitiveTypeProvider.getObject(this.value);
+  }
+
+  @Override
+  public boolean exists() {
+    return this.exists;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("objectId", objectId)
+        .add("domain", domain)
+        .add("key", key)
+        .add("value", value)
+        .toString();
+  }
 }
 

--- a/src/org/vitrivr/cineast/core/db/dao/reader/MultimediaMetadataReader.java
+++ b/src/org/vitrivr/cineast/core/db/dao/reader/MultimediaMetadataReader.java
@@ -1,94 +1,88 @@
 package org.vitrivr.cineast.core.db.dao.reader;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.vitrivr.cineast.core.config.Config;
 import org.vitrivr.cineast.core.data.entities.MultimediaMetadataDescriptor;
 import org.vitrivr.cineast.core.data.providers.primitive.PrimitiveTypeProvider;
 import org.vitrivr.cineast.core.db.DBSelector;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 /**
- * Data access object that facilitates lookups in Cineast's metadata entity (cineast_metadata). Methods in this class
- * usually return MultimediaMetadataDescriptors.
- *
- * @see MultimediaMetadataDescriptor
+ * Data access object that facilitates lookups in Cineast's metadata entity (cineast_metadata).
+ * Methods in this class usually return MultimediaMetadataDescriptors.
  *
  * @author rgasser
  * @version 1.0
  * @created 10.02.17
+ * @see MultimediaMetadataDescriptor
  */
 public class MultimediaMetadataReader extends AbstractEntityReader {
 
-    /**
-     * Default constructor.
-     */
-    public MultimediaMetadataReader(){
-        this(Config.sharedConfig().getDatabase().getSelectorSupplier().get());
+  /**
+   * Default constructor.
+   */
+  public MultimediaMetadataReader() {
+    this(Config.sharedConfig().getDatabase().getSelectorSupplier().get());
+  }
+
+  /**
+   * Constructor for MultimediaMetadataReader
+   *
+   * @param selector DBSelector to use for the MultimediaMetadataReader instance.
+   */
+  public MultimediaMetadataReader(DBSelector selector) {
+    super(selector);
+    this.selector.open(MultimediaMetadataDescriptor.ENTITY);
+  }
+
+  /**
+   * Looks up the metadata for a specific multimedia object.
+   *
+   * @param objectId ID of the multimedia object for which metadata should be retrieved.
+   * @return List of MultimediaMetadataDescriptor object's. May be empty!
+   */
+  public List<MultimediaMetadataDescriptor> lookupMultimediaMetadata(String objectId) {
+    return lookupMultimediaMetadata(ImmutableList.of(objectId));
+  }
+
+  /**
+   * Looks up the metadata for a multiple multimedia objects.
+   *
+   * @param objectIds ID's of the multimedia object's for which metadata should be retrieved.
+   * @return List of MultimediaMetadataDescriptor object's. May be empty!
+   */
+  public List<MultimediaMetadataDescriptor> lookupMultimediaMetadata(String... objectIds) {
+    return lookupMultimediaMetadata(Arrays.asList(objectIds));
+  }
+
+  /**
+   * Looks up the metadata for a multiple multimedia objects.
+   *
+   * @param objectIds ID's of the multimedia object's for which metadata should be retrieved.
+   * @return List of MultimediaMetadataDescriptor object's. May be empty!
+   */
+  public List<MultimediaMetadataDescriptor> lookupMultimediaMetadata(Iterable<String> objectIds) {
+    List<Map<String, PrimitiveTypeProvider>> results = this.selector
+        .getRows(MultimediaMetadataDescriptor.FIELDNAMES[0], objectIds);
+
+    if (results.isEmpty() && !Iterables.isEmpty(objectIds)) {
+      LOGGER.debug("Could not find any MultimediaMetadataDescriptor for provided ID's {}.",
+          objectIds);
     }
 
-    /**
-     * Constructor for MultimediaMetadataReader
-     *
-     * @param selector DBSelector to use for the MultimediaMetadataReader instance.
-     */
-    public MultimediaMetadataReader(DBSelector selector) {
-        super(selector);
-        this.selector.open(MultimediaMetadataDescriptor.ENTITY);
+    List<MultimediaMetadataDescriptor> descriptors = new ArrayList<>(results.size());
+    for (Map<String, PrimitiveTypeProvider> result : results) {
+      try {
+        descriptors.add(new MultimediaMetadataDescriptor(result));
+      } catch (DatabaseLookupException e) {
+        LOGGER.error("Could not map {} to descriptor, ignoring... This is a programmer's error!",
+            result);
+      }
     }
-
-    /**
-     * Looks up the metadata for a specific multimedia object.
-     *
-     * @param objectid ID of the multimedia object for which metadata should be retrieved.
-     * @return List of MultimediaMetadataDescriptor object's. May be empty!
-     */
-    public  List<MultimediaMetadataDescriptor> lookupMultimediaMetadata(String objectid) {
-        List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(MultimediaMetadataDescriptor.FIELDNAMES[0], objectid);
-        ArrayList<MultimediaMetadataDescriptor> list = new ArrayList<>();
-
-        if(results.isEmpty()){
-            LOGGER.debug("Could not find MultimediaMetadataDescriptor with ID {}", objectid);
-            return null;
-        }
-
-        try {
-            for (Map<String, PrimitiveTypeProvider> result : results) {
-                list.add(new MultimediaMetadataDescriptor(result));
-            }
-            return list;
-        } catch (DatabaseLookupException exception) {
-            LOGGER.fatal("Could not map data returned for row {}. This is a programmer's error!", objectid);
-            return null;
-        }
-    }
-
-    /**
-     * Looks up the metadata for a multiple multimedia objects.
-     *
-     * @param objectids ID's of the multimedia object's for which metadata should be retrieved.
-     * @return List of MultimediaMetadataDescriptor object's. May be empty!
-     */
-    public List<MultimediaMetadataDescriptor> lookupMultimediaMetadata(String[] objectids) {
-        List<Map<String, PrimitiveTypeProvider>> results = this.selector.getRows(MultimediaMetadataDescriptor.FIELDNAMES[0], objectids);
-
-        ArrayList<MultimediaMetadataDescriptor> list = new ArrayList<>();
-
-        if(results.isEmpty()){
-            LOGGER.debug("Could not find any MultimediaMetadataDescriptor for provided ID's {}.", (Object[]) objectids);
-            return list;
-        }
-
-        try {
-            for (Map<String, PrimitiveTypeProvider> result : results) {
-                list.add(new MultimediaMetadataDescriptor(result));
-            }
-            return list;
-        } catch (DatabaseLookupException exception) {
-            LOGGER.fatal("Could not map data returned for row. This is a programmer's error!");
-            list.clear();
-            return list;
-        }
-    }
+    return descriptors;
+  }
 }

--- a/src/org/vitrivr/cineast/core/features/SpatialDistance.java
+++ b/src/org/vitrivr/cineast/core/features/SpatialDistance.java
@@ -128,10 +128,10 @@ public class SpatialDistance extends MetadataFeatureModule<Location> {
   public List<MultimediaMetadataDescriptor> createDescriptors(String objectId, Location location) {
     return ImmutableList.of(
         MultimediaMetadataDescriptor
-            .newMultimediaMetadataDescriptor(objectId, this.domain(),
+            .of(objectId, this.domain(),
                 KEY_LATITUDE, location.getLatitude()),
         MultimediaMetadataDescriptor
-            .newMultimediaMetadataDescriptor(objectId, this.domain(),
+            .of(objectId, this.domain(),
                 KEY_LONGITUDE, location.getLongitude())
     );
   }

--- a/src/org/vitrivr/cineast/core/metadata/EXIFMetadataExtractor.java
+++ b/src/org/vitrivr/cineast/core/metadata/EXIFMetadataExtractor.java
@@ -49,7 +49,7 @@ public class EXIFMetadataExtractor implements MetadataExtractor {
             .entrySet().stream()
             .filter(e -> e.getValue() != null)
             .map(e -> MultimediaMetadataDescriptor
-                .newMultimediaMetadataDescriptor(objectId, this.domain(), e.getKey(), e.getValue()))
+                .of(objectId, this.domain(), e.getKey(), e.getValue()))
         ).orElse(Stream.empty()).collect(Collectors.toList());
   }
 

--- a/src/org/vitrivr/cineast/core/metadata/JsonMetadataExtractor.java
+++ b/src/org/vitrivr/cineast/core/metadata/JsonMetadataExtractor.java
@@ -48,7 +48,7 @@ public class JsonMetadataExtractor implements MetadataExtractor {
       Map<String, Object> jsonValues) {
     return jsonValues.entrySet().stream()
         .map(e -> MultimediaMetadataDescriptor
-            .newMultimediaMetadataDescriptor(objectId, this.domain(), e.getKey(), e.getValue()))
+            .of(objectId, this.domain(), e.getKey(), e.getValue()))
         .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Cleaned up and did some refactoring regarding `MultimediaMetadataReader` and `MultimediaMetadataDescriptor`, in particular:

- Added an interactive API command to lookup metadata given object id(s)
- Significantly shortened the factory method name of MultimediaMetadataDescriptor
- Enabled code reuse for the `value` parsing
- Added a sensible `toString` method
- Removed code duplication regarding the lookup methods of `MultimediaMetadataReader` and added another variant using `Iterable`.