### PR TITLE
Added QueryContainers for Location and Instant

### DIFF
--- a/cineast.json
+++ b/cineast.json
@@ -75,6 +75,12 @@
 			],
 			"mfcc" : [
 				{"feature": "MFCCShingle",						"weight": 1.0}
+			],
+			"spatial" : [
+				{"feature": "SpatialDistance",					"weight": 1.0}
+			],
+			"temporal": [
+				{"feature": "TemporalDistance",					"weight": 1.0}
 			]
 		}
 	},

--- a/src/org/vitrivr/cineast/core/data/Location.java
+++ b/src/org/vitrivr/cineast/core/data/Location.java
@@ -6,6 +6,7 @@ import com.drew.lang.GeoLocation;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vitrivr.cineast.core.util.MathHelper;
 
 public class Location implements ReadableFloatVector {
   private static final int ELEMENT_COUNT = 2;
@@ -16,12 +17,18 @@ public class Location implements ReadableFloatVector {
   private final float longitude;
 
   private Location(float latitude, float longitude) {
+    checkNotNaN(latitude, "latitude");
+    checkNotNaN(longitude, "longitude");
     this.latitude = clampLatitude(latitude);
     this.longitude = wrapLongitude(longitude);
   }
 
-  private float clampLatitude(float latitude) {
-    float clamped = Math.max(-90f, Math.min(90f, latitude));
+  private static void checkNotNaN(float value, String type) {
+    checkArgument(!Float.isNaN(value), type + " must be valid number, but found: %", value);
+  }
+
+  private static float clampLatitude(float latitude) {
+    float clamped = MathHelper.limit(latitude, -90f, 90f);
     if (latitude < -90f || latitude > 90f) {
       logger.warn("Latitude value must lie between [-90,90] but found {}, clamping to {}",
           latitude, clamped);
@@ -29,7 +36,7 @@ public class Location implements ReadableFloatVector {
     return clamped;
   }
 
-  private float wrapLongitude(float longitude) {
+  private static float wrapLongitude(float longitude) {
     float wrapped = (longitude % 360f + 360f) % 360f;
     wrapped = wrapped < 180f ? wrapped : wrapped - 360f;
     if (longitude < -180f || longitude >= 180f) {

--- a/src/org/vitrivr/cineast/core/data/messages/query/QueryTerm.java
+++ b/src/org/vitrivr/cineast/core/data/messages/query/QueryTerm.java
@@ -2,17 +2,21 @@ package org.vitrivr.cineast.core.data.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.vitrivr.cineast.api.WebUtils;
+import org.vitrivr.cineast.core.data.GpsData;
 import org.vitrivr.cineast.core.data.MultiImageFactory;
 import org.vitrivr.cineast.core.data.frames.AudioFrame;
 import org.vitrivr.cineast.core.data.query.containers.AudioQueryContainer;
 import org.vitrivr.cineast.core.data.query.containers.ImageQueryContainer;
+import org.vitrivr.cineast.core.data.query.containers.InstantQueryContainer;
+import org.vitrivr.cineast.core.data.query.containers.LocationQueryContainer;
 import org.vitrivr.cineast.core.data.query.containers.QueryContainer;
-
-import java.awt.image.BufferedImage;
-import java.util.Arrays;
-import java.util.List;
+import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 
 /**
  * @author rgasser
@@ -20,63 +24,56 @@ import java.util.List;
  * @created 11.01.17
  */
 public class QueryTerm {
-    /**
-     * List of categories defined as part of the query-term. This ultimately selects the feature-vectors
-     * used for retrieval.
-     */
-    private final String[] categories;
+  private static final JacksonJsonProvider jsonProvider = new JacksonJsonProvider();
 
-    /**
-     *
-     */
-    private final QueryTermType type;
+  /**
+   * List of categories defined as part of the query-term. This ultimately selects the
+   * feature-vectors used for retrieval.
+   */
+  private final String[] categories;
 
-    /**
-     *
-     */
-    private final String data;
+  private final QueryTermType type;
 
-    /**
-     *
-     * @param categories
-     */
-    @JsonCreator
-    public QueryTerm(@JsonProperty("type") QueryTermType type, @JsonProperty("data") String data, @JsonProperty("categories") String[] categories) {
-        this.type = type;
-        this.categories = categories;
-        this.data = data;
+  private final String data;
+
+  @JsonCreator
+  public QueryTerm(@JsonProperty("type") QueryTermType type, @JsonProperty("data") String data,
+      @JsonProperty("categories") String[] categories) {
+    this.type = type;
+    this.categories = categories;
+    this.data = data;
+  }
+
+  public List<String> getCategories() {
+    return Arrays.asList(this.categories);
+  }
+
+  public QueryTermType getType() {
+    return type;
+  }
+
+  @Nullable
+  public QueryContainer toContainer() {
+    switch (this.type) {
+      case IMAGE:
+        // FIXME: image can be null
+        BufferedImage image = WebUtils.dataURLtoBufferedImage(this.data);
+        return new ImageQueryContainer(MultiImageFactory.newInMemoryMultiImage(image));
+      case AUDIO:
+        List<AudioFrame> lists = WebUtils.dataURLtoAudioFrames(this.data);
+        return new AudioQueryContainer(lists);
+      case LOCATION:
+        return Optional
+            .ofNullable(jsonProvider.toJsonNode(this.data))
+            .flatMap(GpsData::parseLocationFromJson)
+            .map(LocationQueryContainer::of)
+            .orElse(null); // TODO: use empty QueryContainer instead?
+      case TIME:
+        return GpsData.parseInstant(this.data)
+            .map(InstantQueryContainer::of)
+            .orElse(null); // TODO: use empty QueryContainer instead?
+      default:
+        return null;
     }
-
-    /**
-     *
-     * @return
-     */
-    public List<String> getCategories() {
-        return Arrays.asList(this.categories);
-    }
-
-    /**
-     *
-     * @return
-     */
-    public QueryTermType getType() {
-        return type;
-    }
-
-    /**
-     *
-     * @return
-     */
-    public QueryContainer toContainer() {
-        switch (this.type) {
-            case IMAGE:
-                BufferedImage image = WebUtils.dataURLtoBufferedImage(this.data);
-                return new ImageQueryContainer(MultiImageFactory.newInMemoryMultiImage(image));
-            case AUDIO:
-                List<AudioFrame> lists = WebUtils.dataURLtoAudioFrames(this.data);
-                return new AudioQueryContainer(lists);
-            default:
-                return null;
-        }
-    }
+  }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/query/QueryTerm.java
+++ b/src/org/vitrivr/cineast/core/data/messages/query/QueryTerm.java
@@ -67,11 +67,11 @@ public class QueryTerm {
             .ofNullable(jsonProvider.toJsonNode(this.data))
             .flatMap(GpsData::parseLocationFromJson)
             .map(LocationQueryContainer::of)
-            .orElse(null); // TODO: use empty QueryContainer instead?
+            .orElse(null);
       case TIME:
         return GpsData.parseInstant(this.data)
             .map(InstantQueryContainer::of)
-            .orElse(null); // TODO: use empty QueryContainer instead?
+            .orElse(null);
       default:
         return null;
     }

--- a/src/org/vitrivr/cineast/core/data/query/containers/InstantQueryContainer.java
+++ b/src/org/vitrivr/cineast/core/data/query/containers/InstantQueryContainer.java
@@ -1,0 +1,60 @@
+package org.vitrivr.cineast.core.data.query.containers;
+
+import com.google.common.base.MoreObjects;
+import java.time.Instant;
+import java.util.Optional;
+
+public class InstantQueryContainer implements QueryContainer {
+  private final Instant instant;
+  private float weight = 0f;
+
+  private InstantQueryContainer(Instant instant) {
+    this.instant = instant;
+  }
+
+  public static InstantQueryContainer of(Instant instant) {
+    return new InstantQueryContainer(instant);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("instant", getInstant())
+        .toString();
+  }
+
+  @Override
+  public Optional<Instant> getInstant() {
+    return Optional.of(this.instant);
+  }
+
+  @Override
+  public float getWeight() {
+    return this.weight;
+  }
+
+  @Override
+  public void setWeight(float weight) {
+    this.weight = weight;
+  }
+
+  @Override
+  public String getId() {
+    return null;
+  }
+
+  @Override
+  public String getSuperId() {
+    return null;
+  }
+
+  @Override
+  public void setId(String id) {
+    // Ignore
+  }
+
+  @Override
+  public void setSuperId(String id) {
+    // Ignore
+  }
+}

--- a/src/org/vitrivr/cineast/core/data/query/containers/InstantQueryContainer.java
+++ b/src/org/vitrivr/cineast/core/data/query/containers/InstantQueryContainer.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public class InstantQueryContainer implements QueryContainer {
   private final Instant instant;
-  private float weight = 0f;
+  private float weight = 1f;
 
   private InstantQueryContainer(Instant instant) {
     this.instant = instant;

--- a/src/org/vitrivr/cineast/core/data/query/containers/LocationQueryContainer.java
+++ b/src/org/vitrivr/cineast/core/data/query/containers/LocationQueryContainer.java
@@ -1,0 +1,61 @@
+package org.vitrivr.cineast.core.data.query.containers;
+
+import com.google.common.base.MoreObjects;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.vitrivr.cineast.core.data.Location;
+
+public class LocationQueryContainer implements QueryContainer {
+  private final Location location;
+  private float weight = 0f;
+
+  private LocationQueryContainer(Location location) {
+    this.location = location;
+  }
+
+  public static LocationQueryContainer of(Location location) {
+    return new LocationQueryContainer(location);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("location", getLocation())
+        .toString();
+  }
+
+  @Override
+  public Optional<Location> getLocation() {
+    return Optional.of(location);
+  }
+
+  @Override
+  public float getWeight() {
+    return this.weight;
+  }
+
+  @Override
+  public void setWeight(float weight) {
+    this.weight = weight;
+  }
+
+  @Override
+  public String getId() {
+    return null;
+  }
+
+  @Override
+  public String getSuperId() {
+    return null;
+  }
+
+  @Override
+  public void setId(String id) {
+    // Ignore
+  }
+
+  @Override
+  public void setSuperId(String id) {
+    // Ignore
+  }
+}

--- a/src/org/vitrivr/cineast/core/data/query/containers/LocationQueryContainer.java
+++ b/src/org/vitrivr/cineast/core/data/query/containers/LocationQueryContainer.java
@@ -7,7 +7,7 @@ import org.vitrivr.cineast.core.data.Location;
 
 public class LocationQueryContainer implements QueryContainer {
   private final Location location;
-  private float weight = 0f;
+  private float weight = 1f;
 
   private LocationQueryContainer(Location location) {
     this.location = location;

--- a/src/org/vitrivr/cineast/core/features/abstracts/MetadataFeatureModule.java
+++ b/src/org/vitrivr/cineast/core/features/abstracts/MetadataFeatureModule.java
@@ -133,7 +133,8 @@ public abstract class MetadataFeatureModule<T extends ReadableFloatVector>
   public List<ScoreElement> getSimilar(SegmentContainer sc, ReadableQueryConfig qc) {
     this.checkIfRetrieverInitialized();
     return this.extractFeature(sc)
-        .map(floatVector -> this.getSimilar(ReadableFloatVector.toArray(floatVector), qc))
+        .map(ReadableFloatVector::toArray)
+        .map(array -> this.getSimilar(array, qc))
         .orElse(Collections.emptyList());
   }
 

--- a/src/org/vitrivr/cineast/core/util/json/JsonReader.java
+++ b/src/org/vitrivr/cineast/core/util/json/JsonReader.java
@@ -1,6 +1,7 @@
 package org.vitrivr.cineast.core.util.json;
 
 import java.io.File;
+import javax.annotation.Nullable;
 
 /**
  * Wraps the Json to Object deserialization so as to make sure that it can be provided
@@ -11,25 +12,27 @@ import java.io.File;
  * @created 13.01.17
  */
 public interface JsonReader {
-    /**
-     * Tries to deserialize a JSON string into a object of the provided class. On error
-     * this method returns null. Exceptions must be handled by the implementation!
-     *
-     * @param jsonString String to deserialize.
-     * @param c Class to which the string should be deserialized.
-     * @param <T> Type of Object that should be returned.
-     * @return Object of type <T> on success or null otherwise.
-     */
-    public <T> T toObject(String jsonString, Class<T> c);
+  /**
+   * Tries to deserialize a JSON string into a object of the provided class. On error
+   * this method returns null. Exceptions must be handled by the implementation!
+   *
+   * @param jsonString String to deserialize.
+   * @param c Class to which the string should be deserialized.
+   * @param <T> Type of Object that should be returned.
+   * @return Object of type T on success or null otherwise.
+   */
+  @Nullable
+  <T> T toObject(String jsonString, Class<T> c);
 
-    /**
-     * Tries to deserialize a JSON file into a object of the provided class. On error
-     * this method returns null. Exceptions must be handled by the implementation!
-     *
-     * @param json File to deserialize.
-     * @param c Class to which the string should be deserialized.
-     * @param <T> Type of Object that should be returned.
-     * @return Object of type <T> on success or null otherwise.
-     */
-    public <T> T toObject(File json, Class<T> c);
+  /**
+   * Tries to deserialize a JSON file into a object of the provided class. On error
+   * this method returns null. Exceptions must be handled by the implementation!
+   *
+   * @param json File to deserialize.
+   * @param c Class to which the string should be deserialized.
+   * @param <T> Type of Object that should be returned.
+   * @return Object of type T on success or null otherwise.
+   */
+  @Nullable
+  <T> T toObject(File json, Class<T> c);
 }

--- a/tests/org/vitrivr/cineast/core/data/LocationTest.java
+++ b/tests/org/vitrivr/cineast/core/data/LocationTest.java
@@ -53,6 +53,13 @@ public class LocationTest {
     }
   }
 
+  @Test
+  @DisplayName("NaN Values")
+  public void testNanValues() {
+    assertThrows(IllegalArgumentException.class, () -> Location.of(Float.NaN, 0f));
+    assertThrows(IllegalArgumentException.class, () -> Location.of(0f, Float.NaN));
+  }
+
   private static void assertFixedCoordinates(float latitude, float longitude) {
     for (Location location : getTestLocations(latitude, longitude)) {
       assertLocationEquals(latitude, longitude, location);

--- a/tests/org/vitrivr/cineast/core/data/LocationTest.java
+++ b/tests/org/vitrivr/cineast/core/data/LocationTest.java
@@ -1,6 +1,7 @@
 package org.vitrivr.cineast.core.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;


### PR DESCRIPTION
This pull request adds query containers for spatial and temporal similarity queries based on a fixed location or a fixed instant, e.g.:
```
{
    "types": ["IMAGE"],
    "containers": [{
        "terms": [
            {
                "categories": ["spatial"],
                "type": "LOCATION",
                "data": "[47.560356, 7.587264]" // or "{ 'latitude': 47.56, 'longitude': 7.58 }"
            }, {
                "categories": ["temporal"],
                "type": "TIME",
                "data": "2016-07-14T13:30:00Z"
            }
        ]
    }]
}
```

Main changes:
* Added `InstantQueryContainer` and `LocationQueryContainer`
* Extended conversion of `QueryTerm` to a `QueryContainer` to support location and instant
* Refactored some parts of `GpsData` to expose the parsing of location and instant