### PR TITLE
Added objectId to signature of MetadataFeatureExtractor.extractFeature

### DIFF
--- a/src/org/vitrivr/cineast/core/features/SpatialDistance.java
+++ b/src/org/vitrivr/cineast/core/features/SpatialDistance.java
@@ -81,7 +81,7 @@ public class SpatialDistance extends MetadataFeatureModule<Location> {
    *         coordinates, if found, otherwise an empty {@code Optional}.
    */
   @Override
-  public Optional<Location> extractFeature(Path objectPath) {
+  public Optional<Location> extractFeature(String objectId, Path objectPath) {
     return GpsData.of(objectPath).location();
   }
 

--- a/src/org/vitrivr/cineast/core/features/TemporalDistance.java
+++ b/src/org/vitrivr/cineast/core/features/TemporalDistance.java
@@ -71,7 +71,7 @@ public class TemporalDistance extends MetadataFeatureModule<InstantVector> {
    *         JSON timestamp, if found, otherwise an empty {@code Optional}.
    */
   @Override
-  public Optional<InstantVector> extractFeature(Path object) {
+  public Optional<InstantVector> extractFeature(String objectId, Path object) {
     return GpsData.of(object).time().map(InstantVector::of);
   }
 

--- a/src/org/vitrivr/cineast/core/features/abstracts/MetadataFeatureModule.java
+++ b/src/org/vitrivr/cineast/core/features/abstracts/MetadataFeatureModule.java
@@ -119,7 +119,7 @@ public abstract class MetadataFeatureModule<T extends ReadableFloatVector>
   @Override
   public List<MultimediaMetadataDescriptor> extract(String objectId, Path path) {
     checkState(this.isExtractorInitialized(), "extract called before init");
-    Optional<T> feature = this.extractFeature(path);
+    Optional<T> feature = this.extractFeature(objectId, path);
     feature.ifPresent(v -> this.featureWriter.write(new SimpleFeatureDescriptor(objectId, v)));
     return feature
         .map(floatVector -> this.createDescriptors(objectId, floatVector))

--- a/src/org/vitrivr/cineast/core/metadata/MetadataFeatureExtractor.java
+++ b/src/org/vitrivr/cineast/core/metadata/MetadataFeatureExtractor.java
@@ -22,7 +22,7 @@ public interface MetadataFeatureExtractor<T> extends MetadataExtractor {
    */
   @Override
   default List<MultimediaMetadataDescriptor> extract(String objectId, Path path) {
-    return this.extractFeature(path)
+    return this.extractFeature(objectId, path)
         .map(floatVector -> this.createDescriptors(objectId, floatVector))
         .orElse(Collections.emptyList());
   }
@@ -31,7 +31,7 @@ public interface MetadataFeatureExtractor<T> extends MetadataExtractor {
    * Returns an {@link Optional} containing the extracted feature data from the file, if found,
    * otherwise an empty {@code Optional}.
    */
-  Optional<T> extractFeature(Path path);
+  Optional<T> extractFeature(String objectId, Path path);
 
   /** Returns a list of descriptors of the given feature data. */
   List<MultimediaMetadataDescriptor> createDescriptors(String objectId, T feature);


### PR DESCRIPTION
Because the object id already gets extracted from the file using an `ObjectIdGenerator`, there is no reason to withhold this information from classes implementing `MetadataFeatureExtractor`.

Note that the current features implementing this interface do not make use of this.