### PR TITLE
Relative input paths now resolved against directory of job file

### DIFF
--- a/src/org/vitrivr/cineast/core/run/ExtractionDispatcher.java
+++ b/src/org/vitrivr/cineast/core/run/ExtractionDispatcher.java
@@ -57,7 +57,8 @@ public class ExtractionDispatcher {
         
         /* Check if context could be read and an input path was specified. */
         if (context == null || this.context.inputPath() == null) return false;
-        Path path = this.context.inputPath();
+        Path jobDirectory = jobFile.toPath().getParent();
+        Path path = jobDirectory.resolve(this.context.inputPath()).normalize();
         
         /*
          * Recursively add all files under that path to the List of files that should be processed. Uses the context-provider


### PR DESCRIPTION
Currently, relative input paths of job files get resolved against the working directory of Java which is usually the top directory of Cineast. When working with multiple, different datasets or collections, this behaviour is usually restrictive because it does not allow to create job files with relative paths inside some other directory unrelated to Cineast.

This pull request changes the path resolution of a relative path to use the directory of the job file.

A common use case would be to create one directory for a collection with an accompanying job file, e.g.:

    some-collection
    ├── image0001.jpg
    ├── image0002.jpg
    ├── image0003.jpg
    ├── image0004.jpg
     ⋮
    ├── movie0001.mp4
    ├── movie0002.mp4
    ├── movie0003.mp4
     ⋮
    ├── job.json

With this pull request, the job file can make use a relative path for the input files: `"input": { "path": "." }`.