### PR TITLE
Small cleanup for messages

### DIFF
--- a/src/org/vitrivr/cineast/api/rest/RestfulAPI.java
+++ b/src/org/vitrivr/cineast/api/rest/RestfulAPI.java
@@ -68,7 +68,7 @@ public class RestfulAPI {
       
       http.get("/segments/all/object/:id", new FindSegmentAllByObjectIdActionHandler());
             
-      http.post("/segments/similar/", new FindSegmentSimilarActionHandler());
+      http.post("/segments/similar", new FindSegmentSimilarActionHandler());
       
       http.post("/segments/by/id", new FindSegmentsByIdActionHandler());
       http.post("/objects/by/id", new FindObjectsByIdActionHandler());

--- a/src/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
+++ b/src/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
@@ -11,7 +11,7 @@ import org.vitrivr.cineast.api.websocket.handlers.QueryMessageHandler;
 import org.vitrivr.cineast.api.websocket.handlers.StatusMessageHandler;
 import org.vitrivr.cineast.api.websocket.handlers.interfaces.WebsocketMessageHandler;
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.messages.general.AnyMessage;
 import org.vitrivr.cineast.core.util.LogHelper;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
@@ -56,16 +56,16 @@ public class WebsocketAPI {
     private static final String VERSION = "v1";
 
     /** List of stateless WebsocketMessageHandler classes for the API. */
-    private static final HashMap<MessageTypes, WebsocketMessageHandler<?>> STATELESS_HANDLERS = new HashMap<>();
+    private static final HashMap<MessageType, WebsocketMessageHandler<?>> STATELESS_HANDLERS = new HashMap<>();
 
     /** Flag that indicates whether the WebSocket API is running. */
     private static AtomicBoolean RUNNING = new AtomicBoolean(false);
 
     /* Register the MessageHandlers for the different messages. */
     static {
-        STATELESS_HANDLERS.put(MessageTypes.Q_QUERY, new QueryMessageHandler());
-        STATELESS_HANDLERS.put(MessageTypes.PING, new StatusMessageHandler());
-        STATELESS_HANDLERS.put(MessageTypes.M_LOOKUP, new MetadataLookupMessageHandler());
+        STATELESS_HANDLERS.put(MessageType.Q_QUERY, new QueryMessageHandler());
+        STATELESS_HANDLERS.put(MessageType.PING, new StatusMessageHandler());
+        STATELESS_HANDLERS.put(MessageType.M_LOOKUP, new MetadataLookupMessageHandler());
     }
 
     /* */
@@ -113,7 +113,7 @@ public class WebsocketAPI {
      * @param type MessageType for which a new handler should be regiestered.
      * @param handler Instance of WebsocketMessageHandler.
      */
-    private static void registerHandlerForMessageType(MessageTypes type, WebsocketMessageHandler<?> handler) {
+    private static void registerHandlerForMessageType(MessageType type, WebsocketMessageHandler<?> handler) {
         if (handler.isStateless()) {
             STATELESS_HANDLERS.put(type, handler);
         }
@@ -170,7 +170,7 @@ public class WebsocketAPI {
     public void message(Session session, String message) throws IOException {
         AnyMessage testMessage = reader.toObject(message, AnyMessage.class);
         if (testMessage != null) {
-            MessageTypes type = testMessage.getMessagetype();
+            MessageType type = testMessage.getMessageType();
             WebsocketMessageHandler handler = STATELESS_HANDLERS.get(type);
             if (handler != null) {
                 handler.handle(session, reader.toObject(message, type.getMessageClass()));

--- a/src/org/vitrivr/cineast/core/data/messages/general/AnyMessage.java
+++ b/src/org/vitrivr/cineast/core/data/messages/general/AnyMessage.java
@@ -3,7 +3,7 @@ package org.vitrivr.cineast.core.data.messages.general;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 /**
  * @author rgasser
@@ -11,14 +11,14 @@ import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
  * @created 19.01.17
  */
 public class AnyMessage implements Message {
-    private MessageTypes messagetype;
+    private MessageType messageType;
 
     @Override
     @JsonProperty
-    public MessageTypes getMessagetype() {
-        return this.messagetype;
+    public MessageType getMessageType() {
+        return this.messageType;
     }
-    public void setMessagetype(MessageTypes messagetype) {
-        this.messagetype = messagetype;
+    public void setMessagetype(MessageType messageType) {
+        this.messageType = messageType;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/general/Error.java
+++ b/src/org/vitrivr/cineast/core/data/messages/general/Error.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 /**
  * @author rgasser
@@ -44,7 +44,7 @@ public class Error implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
+    public MessageType getMessageType() {
         return null;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/general/Ping.java
+++ b/src/org/vitrivr/cineast/core/data/messages/general/Ping.java
@@ -2,7 +2,7 @@ package org.vitrivr.cineast.core.data.messages.general;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 /**
  * @author rgasser
@@ -31,7 +31,7 @@ public class Ping implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
-        return MessageTypes.PING;
+    public MessageType getMessageType() {
+        return MessageType.PING;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/interfaces/Message.java
+++ b/src/org/vitrivr/cineast/core/data/messages/interfaces/Message.java
@@ -14,5 +14,5 @@ public interface Message {
      *
      * @return
      */
-    public MessageTypes getMessagetype();
+    public MessageType getMessageType();
 }

--- a/src/org/vitrivr/cineast/core/data/messages/interfaces/MessageType.java
+++ b/src/org/vitrivr/cineast/core/data/messages/interfaces/MessageType.java
@@ -13,7 +13,7 @@ import org.vitrivr.cineast.core.data.messages.session.StartSessionMessage;
  * @version 1.0
  * @created 12.01.17
  */
-public enum MessageTypes {
+public enum MessageType {
 
     /* Messages related to status updates. */
     PING(Ping.class),
@@ -29,7 +29,7 @@ public enum MessageTypes {
   
     private Class<? extends Message> c;
 
-    MessageTypes(Class<? extends Message> c) {
+    MessageType(Class<? extends Message> c) {
         this.c = c;
     }
 

--- a/src/org/vitrivr/cineast/core/data/messages/lookup/IdList.java
+++ b/src/org/vitrivr/cineast/core/data/messages/lookup/IdList.java
@@ -1,7 +1,7 @@
 package org.vitrivr.cineast.core.data.messages.lookup;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,7 +20,7 @@ public class IdList implements Message {
   }
   
   @Override
-  public MessageTypes getMessagetype() {
+  public MessageType getMessageType() {
     return null;
   }
 

--- a/src/org/vitrivr/cineast/core/data/messages/lookup/MetadataLookup.java
+++ b/src/org/vitrivr/cineast/core/data/messages/lookup/MetadataLookup.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 /**
  * @author rgasser
@@ -55,7 +55,7 @@ public class MetadataLookup implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
+    public MessageType getMessageType() {
         return null;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/query/Query.java
+++ b/src/org/vitrivr/cineast/core/data/messages/query/Query.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,7 +51,7 @@ public class Query implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
-        return MessageTypes.Q_QUERY;
+    public MessageType getMessageType() {
+        return MessageType.Q_QUERY;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/result/MetadataQueryResult.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/MetadataQueryResult.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import org.vitrivr.cineast.core.data.entities.MultimediaMetadataDescriptor;
 import org.vitrivr.cineast.core.data.messages.abstracts.AbstractQueryResultMessage;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.List;
 
-import static org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes.QR_METADATA;
+import static org.vitrivr.cineast.core.data.messages.interfaces.MessageType.QR_METADATA;
 
 /**
  * @author rgasser
@@ -29,7 +29,7 @@ public class MetadataQueryResult extends AbstractQueryResultMessage<MultimediaMe
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
+    public MessageType getMessageType() {
         return QR_METADATA;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/result/ObjectQueryResult.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/ObjectQueryResult.java
@@ -3,7 +3,7 @@ package org.vitrivr.cineast.core.data.messages.result;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.vitrivr.cineast.core.data.entities.MultimediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.messages.abstracts.AbstractQueryResultMessage;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.List;
 
@@ -28,7 +28,7 @@ public class ObjectQueryResult extends AbstractQueryResultMessage<MultimediaObje
      *
      * @return
      */
-    public MessageTypes getMessagetype() {
-        return MessageTypes.QR_OBJECT;
+    public MessageType getMessageType() {
+        return MessageType.QR_OBJECT;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/result/QueryEnd.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/QueryEnd.java
@@ -1,7 +1,7 @@
 package org.vitrivr.cineast.core.data.messages.result;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 /**
  * @author rgasser
@@ -26,8 +26,8 @@ public class QueryEnd implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
-        return MessageTypes.QR_END;
+    public MessageType getMessageType() {
+        return MessageType.QR_END;
     }
 
     /**

--- a/src/org/vitrivr/cineast/core/data/messages/result/QueryStart.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/QueryStart.java
@@ -1,7 +1,7 @@
 package org.vitrivr.cineast.core.data.messages.result;
 
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.UUID;
 
@@ -29,8 +29,8 @@ public class QueryStart implements Message {
      * @return
      */
     @Override
-    public MessageTypes getMessagetype() {
-        return MessageTypes.QR_START;
+    public MessageType getMessageType() {
+        return MessageType.QR_START;
     }
 
     /**

--- a/src/org/vitrivr/cineast/core/data/messages/result/SegmentQueryResult.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/SegmentQueryResult.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import org.vitrivr.cineast.core.data.entities.SegmentDescriptor;
 import org.vitrivr.cineast.core.data.messages.abstracts.AbstractQueryResultMessage;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.List;
 
@@ -27,7 +27,7 @@ public class SegmentQueryResult extends AbstractQueryResultMessage<SegmentDescri
      *
      * @return
      */
-    public MessageTypes getMessagetype() {
-        return MessageTypes.QR_SEGMENT;
+    public MessageType getMessageType() {
+        return MessageType.QR_SEGMENT;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/result/SimilarityQueryResult.java
+++ b/src/org/vitrivr/cineast/core/data/messages/result/SimilarityQueryResult.java
@@ -3,7 +3,7 @@ package org.vitrivr.cineast.core.data.messages.result;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.vitrivr.cineast.core.data.StringDoublePair;
 import org.vitrivr.cineast.core.data.messages.abstracts.AbstractQueryResultMessage;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoub
      *
      * @return
      */
-    public MessageTypes getMessagetype() {
-        return MessageTypes.QR_SIMILARITY;
+    public MessageType getMessageType() {
+        return MessageType.QR_SIMILARITY;
     }
 }

--- a/src/org/vitrivr/cineast/core/data/messages/session/StartSessionMessage.java
+++ b/src/org/vitrivr/cineast/core/data/messages/session/StartSessionMessage.java
@@ -2,7 +2,7 @@ package org.vitrivr.cineast.core.data.messages.session;
 
 import org.vitrivr.cineast.core.data.messages.credentials.Credentials;
 import org.vitrivr.cineast.core.data.messages.interfaces.Message;
-import org.vitrivr.cineast.core.data.messages.interfaces.MessageTypes;
+import org.vitrivr.cineast.core.data.messages.interfaces.MessageType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,8 +21,8 @@ public class StartSessionMessage implements Message {
   }
   
   @Override
-  public MessageTypes getMessagetype() {
-    return MessageTypes.SESSION_START;
+  public MessageType getMessageType() {
+    return MessageType.SESSION_START;
   }
 
   @Override


### PR DESCRIPTION
* Renamed enum `MessageTypes` to `MessageType`
* Fixed method naming of `Message.getMessageType` (camelcase)
* Removed the ending slash of the Restful similarity query `find/segments/similar`