### PR TITLE
Added AutoCloseable to multiple classes and interfaces.

### DIFF
--- a/src/org/vitrivr/cineast/core/data/providers/SegmentProvider.java
+++ b/src/org/vitrivr/cineast/core/data/providers/SegmentProvider.java
@@ -2,7 +2,7 @@ package org.vitrivr.cineast.core.data.providers;
 
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 
-public interface SegmentProvider {
+public interface SegmentProvider extends AutoCloseable {
 
   /**
    * 

--- a/src/org/vitrivr/cineast/core/db/ADAMproWrapper.java
+++ b/src/org/vitrivr/cineast/core/db/ADAMproWrapper.java
@@ -29,7 +29,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 
-public class ADAMproWrapper {
+public class ADAMproWrapper implements AutoCloseable {
 
   private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/org/vitrivr/cineast/core/db/NeuralNetLookup.java
+++ b/src/org/vitrivr/cineast/core/db/NeuralNetLookup.java
@@ -12,7 +12,7 @@ import org.vitrivr.cineast.core.features.neuralnet.NeuralNetFeature;
 /**
  * Created by silvan on 13.09.16.
  */
-public class NeuralNetLookup {
+public class NeuralNetLookup implements AutoCloseable {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private final DBSelector selector;

--- a/src/org/vitrivr/cineast/core/db/dao/writer/AbstractBatchedEntityWriter.java
+++ b/src/org/vitrivr/cineast/core/db/dao/writer/AbstractBatchedEntityWriter.java
@@ -1,127 +1,131 @@
 package org.vitrivr.cineast.core.db.dao.writer;
 
-import org.vitrivr.cineast.core.db.PersistencyWriter;
-import org.vitrivr.cineast.core.db.PersistentTuple;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.vitrivr.cineast.core.db.PersistencyWriter;
+import org.vitrivr.cineast.core.db.PersistentTuple;
 
 /**
  * @author rgasser
  * @version 1.0
  * @created 27.01.17
  */
-public abstract class AbstractBatchedEntityWriter<T> {
-    /** */
-    private final ArrayDeque<PersistentTuple> buffer;
+public abstract class AbstractBatchedEntityWriter<T> implements AutoCloseable {
+  /** */
+  private final ArrayDeque<PersistentTuple> buffer;
 
-    /** */
-    private final int batchsize;
+  /** */
+  private final int batchsize;
 
-    /** PersistencyWriter instance used to persist changes. */
-    protected PersistencyWriter<?> writer;
+  /** PersistencyWriter instance used to persist changes. */
+  protected PersistencyWriter<?> writer;
 
-    /**
-     *
-     * @param writer
-     * @param batchsize
-     */
-    protected AbstractBatchedEntityWriter(PersistencyWriter<?> writer, int batchsize, boolean init) {
-        this.buffer = new ArrayDeque<>(batchsize);
-        this.batchsize = batchsize;
-        this.writer = writer;
-        if (init) this.init();
+  /**
+   *
+   * @param writer
+   * @param batchsize
+   */
+  protected AbstractBatchedEntityWriter(PersistencyWriter<?> writer, int batchsize, boolean init) {
+    this.buffer = new ArrayDeque<>(batchsize);
+    this.batchsize = batchsize;
+    this.writer = writer;
+    if (init) {
+      this.init();
+    }
+  }
+
+  /**
+   *
+   */
+  protected abstract void init();
+
+  /**
+   *
+   * @param entity
+   * @return
+   */
+  protected abstract PersistentTuple generateTuple(T entity);
+
+
+  /**
+   * Persists the provided entity descriptor in the database.
+   *
+   * @param entity Entity descriptor to persist
+   */
+  public void write(T entity) {
+    PersistentTuple tuple = this.generateTuple(entity);
+    if (this.batchsize == 1) {
+      this.writeSingle(tuple);
+    } else {
+      this.writeBatched(tuple);
+    }
+  }
+
+  /**
+   *
+   * @param entity
+   */
+  public void write(List<T> entity) {
+    if (entity.size() < this.batchsize) {
+      List<PersistentTuple> tuples = entity.stream().map(this::generateTuple)
+          .collect(Collectors.toList());
+      this.writer.persist(tuples);
+    } else {
+      entity.stream().map(this::generateTuple).forEach(this::writeBatched);
+    }
+  }
+
+  /**
+   *
+   */
+  public final void flush() {
+    List<PersistentTuple> batch = new ArrayList<>(buffer.size());
+    PersistentTuple t = null;
+    while ((t = this.buffer.poll()) != null) {
+      batch.add(t);
+    }
+    this.writer.persist(batch);
+  }
+
+  /**
+   *
+   * @param tuple
+   */
+  private void writeSingle(PersistentTuple tuple) {
+    this.writer.persist(tuple);
+  }
+
+  /**
+   *
+   * @param tuple
+   */
+  private void writeBatched(PersistentTuple tuple) {
+    this.buffer.offer(tuple);
+    if (buffer.size() >= this.batchsize) {
+      this.flush();
+    }
+  }
+
+  /**
+   * Flushes the buffer and closes the writer.
+   */
+  public final void close() {
+    if (this.buffer.size() > 0) {
+      this.flush();
     }
 
-    /**
-     *
-     */
-    protected abstract void init();
-
-    /**
-     *
-     * @param entity
-     * @return
-     */
-    protected abstract PersistentTuple generateTuple(T entity);
-
-
-    /**
-     * Persists the provided entity descriptor in the database.
-     *
-     * @param entity Entity descriptor to persist
-     */
-    public void write(T entity) {
-        PersistentTuple tuple = this.generateTuple(entity);
-        if (this.batchsize == 1) {
-            this.writeSingle(tuple);
-        } else {
-            this.writeBatched(tuple);
-        }
+    if (this.writer != null) {
+      this.writer.close();
+      this.writer = null;
     }
+  }
 
-    /**
-     *
-     * @param entity
-     */
-    public void write(List<T> entity) {
-        if (entity.size() < this.batchsize) {
-            List<PersistentTuple> tuples = entity.stream().map(this::generateTuple).collect(Collectors.toList());
-            this.writer.persist(tuples);
-        } else {
-            entity.stream().map(this::generateTuple).forEach(this::writeBatched);
-        }
-    }
-
-    /**
-     *
-     */
-    public final void flush() {
-        List<PersistentTuple> batch = new ArrayList<>(buffer.size());
-        PersistentTuple t = null;
-        while ((t = this.buffer.poll()) != null) {
-            batch.add(t);
-        }
-        this.writer.persist(batch);
-    }
-
-    /**
-     *
-     * @param tuple
-     */
-    private void writeSingle(PersistentTuple tuple) {
-        this.writer.persist(tuple);
-    }
-
-    /**
-     *
-     * @param tuple
-     */
-    private void writeBatched(PersistentTuple tuple) {
-        this.buffer.offer(tuple);
-        if (buffer.size() >= this.batchsize) {
-            this.flush();
-        }
-    }
-
-    /**
-     * Flushes the buffer and closes the writer.
-     */
-    public final void close() {
-        if (this.buffer.size() > 0) this.flush();
-
-        if(this.writer != null){
-            this.writer.close();
-            this.writer = null;
-        }
-    }
-
-    /**
-     *
-     */
-    public void finalize() {
-        this.close();
-    }
+  /**
+   *
+   */
+  public void finalize() {
+    this.close();
+  }
 }

--- a/src/org/vitrivr/cineast/core/decode/general/Decoder.java
+++ b/src/org/vitrivr/cineast/core/decode/general/Decoder.java
@@ -18,7 +18,7 @@ import java.util.Set;
  * @version 1.0
  * @created 13.01.17
  */
-public interface Decoder<T> {
+public interface Decoder<T> extends AutoCloseable {
     /**
      * Initializes the decoder with a file. This is a necessary step before content can be retrieved from
      * the decoder by means of the getNext() method.

--- a/src/org/vitrivr/cineast/core/decode/video/VideoDecoder.java
+++ b/src/org/vitrivr/cineast/core/decode/video/VideoDecoder.java
@@ -3,7 +3,7 @@ package org.vitrivr.cineast.core.decode.video;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
 
 @Deprecated
-public interface VideoDecoder {
+public interface VideoDecoder extends AutoCloseable {
 
 	void seekToFrame(int frameNumber);
 

--- a/src/org/vitrivr/cineast/core/segmenter/general/Segmenter.java
+++ b/src/org/vitrivr/cineast/core/segmenter/general/Segmenter.java
@@ -12,7 +12,7 @@ import org.vitrivr.cineast.core.decode.general.Decoder;
  * @version 1.0
  * @created 16.01.17
  */
-public interface Segmenter<A> extends Runnable {
+public interface Segmenter<A> extends Runnable, AutoCloseable {
     /**
      * Method used to initialize the Segmenter. A class implementing the Decoder interface
      * with the same type must be provided.

--- a/src/org/vitrivr/cineast/core/setup/EntityCreator.java
+++ b/src/org/vitrivr/cineast/core/setup/EntityCreator.java
@@ -12,7 +12,7 @@ import org.vitrivr.cineast.core.features.retriever.Retriever;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public interface EntityCreator {
+public interface EntityCreator extends AutoCloseable {
     /**
      * Logger instance used for logging.
      */


### PR DESCRIPTION
Multiple class and interfaces contained a `close` method but did not implement `AutoCloseable`. With this change, all of the affected classes/interfaces can now be used in try-with-resource constructs.