### PR TITLE
Restarting Sessions

### DIFF
--- a/src/org/vitrivr/cineast/api/API.java
+++ b/src/org/vitrivr/cineast/api/API.java
@@ -91,7 +91,24 @@ public class API {
       }
       PrometheusServer.initialize();
 
-            /* Handle --job; start handleExtraction. */
+      /* Handle --setup; start database setup. */
+      if (commandline.hasOption("setup")) {
+        HashMap<String, String> options = new HashMap<>();
+        String optionValue = commandline.getOptionValue("setup");
+        String[] flags = optionValue != null ? optionValue.split(";") : new String[0];
+        for (String flag : flags) {
+          String[] pair = flag.split("=");
+          if (pair.length == 2) {
+            options.put(pair[0], pair[1]);
+          }
+        }
+        handleSetup(options);
+        PrometheusServer.stopServer();
+        return;
+      }
+
+
+      /* Handle --job; start handleExtraction. */
       if (commandline.hasOption("job")) {
         handleExtraction(new File(commandline.getOptionValue("job")));
         return;
@@ -107,20 +124,6 @@ public class API {
         return;
       }
 
-      /* Handle --setup; start database setup. */
-      if (commandline.hasOption("setup")) {
-        HashMap<String, String> options = new HashMap<>();
-        String optionValue = commandline.getOptionValue("setup");
-        String[] flags = optionValue != null ? optionValue.split(";") : new String[0];
-        for (String flag : flags) {
-          String[] pair = flag.split("=");
-          if (pair.length == 2) {
-            options.put(pair[0], pair[1]);
-          }
-        }
-        handleSetup(options);
-        return;
-      }
 
       /* Handle -i; start CLI. */
       if (Config.sharedConfig().getApi().getEnableCli() || commandline.hasOption('i')) {

--- a/src/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/src/org/vitrivr/cineast/api/APIEndpoint.java
@@ -8,6 +8,7 @@ import org.vitrivr.cineast.api.rest.handlers.actions.*;
 import org.vitrivr.cineast.api.rest.handlers.actions.session.EndExtractionHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.session.EndSessionHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.session.ExtractItemHandler;
+import org.vitrivr.cineast.api.rest.handlers.actions.session.StartExtractionHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.session.StartSessionHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.session.ValidateSessionHandler;
 import org.vitrivr.cineast.api.rest.handlers.interfaces.ActionHandler;
@@ -161,6 +162,7 @@ public class APIEndpoint {
             service.get("/validate/:id", new ValidateSessionHandler());
             service.post("/extract/new", new ExtractItemHandler());
             service.post("/extract/end", new EndExtractionHandler());
+            service.post("/extract/start", new StartExtractionHandler());
         });
         if (Config.sharedConfig().getApi().getServeContent()) {
           service.path(makePath("get"), () -> {

--- a/src/org/vitrivr/cineast/api/SessionExtractionContainer.java
+++ b/src/org/vitrivr/cineast/api/SessionExtractionContainer.java
@@ -1,19 +1,15 @@
 package org.vitrivr.cineast.api;
 
-import com.google.common.collect.Lists;
 import io.prometheus.client.Counter;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.config.Config;
 import org.vitrivr.cineast.core.config.IngestConfig;
 import org.vitrivr.cineast.core.run.ExtractionContextProvider;
 import org.vitrivr.cineast.core.run.ExtractionDispatcher;
-import org.vitrivr.cineast.core.run.ExtractionContainerProvider;
 import org.vitrivr.cineast.core.run.ExtractionItemContainer;
 import org.vitrivr.cineast.core.run.path.SessionContainerProvider;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
@@ -78,10 +74,12 @@ public class SessionExtractionContainer {
    */
   public static void restartExceptCounter() {
     provider.close();
+    LOGGER.debug("Restarting SessionPathProvider");
     initalizeExtraction();
   }
 
   public static void close() {
+    LOGGER.debug("Closing session");
     provider.close();
     open = false;
   }
@@ -92,10 +90,6 @@ public class SessionExtractionContainer {
       return;
     }
     provider.endSession();
-  }
-
-  public static boolean isOpen() {
-    return open;
   }
 
   public static void addPaths(ExtractionItemContainer[] items) {
@@ -114,4 +108,12 @@ public class SessionExtractionContainer {
     provider.addPaths(Arrays.asList(items));
   }
 
+  /**
+   * Marks as not closing anymore. Provides a best-effort to synchronize.
+   *
+   * @return if the underlying provider is closed
+   */
+  public static boolean keepAliveCheckIfClosed() {
+    return provider.keepAliveCheckIfClosed();
+  }
 }

--- a/src/org/vitrivr/cineast/api/rest/handlers/actions/session/StartExtractionHandler.java
+++ b/src/org/vitrivr/cineast/api/rest/handlers/actions/session/StartExtractionHandler.java
@@ -1,0 +1,42 @@
+package org.vitrivr.cineast.api.rest.handlers.actions.session;
+
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.vitrivr.cineast.api.SessionExtractionContainer;
+import org.vitrivr.cineast.api.rest.exceptions.ActionHandlerException;
+import org.vitrivr.cineast.api.rest.handlers.abstracts.ParsingActionHandler;
+import org.vitrivr.cineast.core.data.messages.general.AnyMessage;
+import org.vitrivr.cineast.core.data.messages.session.SessionState;
+
+/**
+ * @author silvan on 23.01.18.
+ */
+public class StartExtractionHandler extends ParsingActionHandler<AnyMessage> {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  @Override
+  public Object doGet(Map<String, String> parameters) throws ActionHandlerException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object doPost(AnyMessage context, Map<String, String> parameters)
+      throws ActionHandlerException {
+    SessionState state = ValidateSessionHandler.validateSession(parameters); //TODO Use State
+
+    if (SessionExtractionContainer.keepAliveCheckIfClosed()) {
+      LOGGER.info("Session is closed, restarting");
+      SessionExtractionContainer.restartExceptCounter();
+      return state;
+    }
+    LOGGER.debug("Only sent keepAlive message");
+    return state;
+  }
+
+  @Override
+  public Class<AnyMessage> inClass() {
+    return AnyMessage.class;
+  }
+}

--- a/src/org/vitrivr/cineast/core/run/filehandler/GenericExtractionItemHandler.java
+++ b/src/org/vitrivr/cineast/core/run/filehandler/GenericExtractionItemHandler.java
@@ -266,6 +266,7 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
       this.metadataWriter.close();
       this.objectReader.close();
       this.segmentReader.close();
+      LOGGER.debug("Done");
     }
   }
 
@@ -275,7 +276,7 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
       return null;
     }
     if (!this.pathProvider.isOpen()) {
-      LOGGER.error("Pathprovider closed, returning null");
+      LOGGER.error("Pathprovider closed upon entrance, returning null");
       return null;
     }
     int sleep = 0;
@@ -284,8 +285,8 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
         Optional<ExtractionItemContainer> providerResult = pathProvider.next();
         if (!providerResult.isPresent()) {
           try {
-            Thread.sleep(1);
-            sleep+=1;
+            Thread.sleep(100);
+            sleep+=100;
             if(sleep>60_000){
               LOGGER.debug("Path provider is still open, but no new element has been received in the last 60 seconds");
             }
@@ -305,7 +306,7 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
         //TODO Add support for separate filesystems.
       } else {
         try {
-          Thread.sleep(5);
+          Thread.sleep(100);
         } catch (InterruptedException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
# Current Limitations
* You need to use the UniqueIDGenerator if you're restarting sessions. The current implementation restarts the whole pipeline which means that a new IDGenerator is created, which results in the SequentialIdGenerator being unusable for this specific feature.