### PR TITLE
Filtering empty exif-values to prevent RTE

### DIFF
--- a/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
+++ b/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
@@ -1,6 +1,7 @@
 package org.vitrivr.cineast.core.data.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -185,6 +186,11 @@ public class MultimediaMetadataDescriptor implements ExistenceCheck {
   @JsonProperty
   public String getValue() {
     return this.value.getString();
+  }
+
+  @JsonIgnore
+  public PrimitiveTypeProvider getValueProvider(){
+    return this.value;
   }
 
   @Override

--- a/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
+++ b/src/org/vitrivr/cineast/core/data/entities/MultimediaMetadataDescriptor.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.StringValue;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -101,14 +103,21 @@ public class MultimediaMetadataDescriptor implements ExistenceCheck {
     this.domain = domain;
     this.exists = exists;
 
+    outer:
     if (value != null & isSupportedValue(value)) {
       this.value = new StringTypeProvider(value.toString());
     } else {
       if (value instanceof StringProvider) {
         this.value = new StringTypeProvider(((StringProvider) value).getString());
-      } else {
-        LOGGER.warn("Value type {} not supported, value is {}", value.getClass().getSimpleName()
-            , value.toString());
+        break outer;
+      }
+      if(value instanceof com.drew.metadata.StringValue){
+        this.value = new StringTypeProvider(((com.drew.metadata.StringValue) value).toString(Charset
+            .defaultCharset()));
+      }
+      else {
+        LOGGER.warn("Value type {} not supported, value is {} for key {}", value.getClass().getSimpleName()
+            , value.toString(), key);
         this.value = new NothingProvider();
       }
     }

--- a/src/org/vitrivr/cineast/core/db/dao/writer/MultimediaMetadataWriter.java
+++ b/src/org/vitrivr/cineast/core/db/dao/writer/MultimediaMetadataWriter.java
@@ -34,6 +34,7 @@ public class MultimediaMetadataWriter extends AbstractBatchedEntityWriter<Multim
      */
     @Override
     protected PersistentTuple generateTuple(MultimediaMetadataDescriptor entity) {
-        return this.writer.generateTuple(entity.getObjectId(), entity.getDomain(), entity.getKey(), entity.getValue().toString());
+        return this.writer.generateTuple(entity.getObjectId(), entity.getDomain(), entity.getKey(),
+            entity.getValue());
     }
 }

--- a/src/org/vitrivr/cineast/core/metadata/EXIFMetadataExtractor.java
+++ b/src/org/vitrivr/cineast/core/metadata/EXIFMetadataExtractor.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.vitrivr.cineast.core.data.entities.MultimediaMetadataDescriptor;
+import org.vitrivr.cineast.core.data.providers.primitive.NothingProvider;
 import org.vitrivr.cineast.core.util.MetadataUtil;
 
 /**
@@ -59,6 +60,7 @@ public class EXIFMetadataExtractor implements MetadataExtractor {
     Set<Entry<String, Object>> set = Maps.transformValues(FIELDS, md::getObject).entrySet();
     return set.stream().filter(e -> e.getValue() != null).map(
         e -> MultimediaMetadataDescriptor.of(objectId, this.domain(), e.getKey(), e.getValue()))
+        .filter(e -> ! (e.getValueProvider() instanceof NothingProvider))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
If the given EXIF-Metadata value is a byte-array or something unsupported, it will now be ignored instead of throwing a RuntimeException