### PR TITLE
Implemented Add Media API.

### DIFF
--- a/src/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/src/org/vitrivr/cineast/api/APIEndpoint.java
@@ -164,6 +164,7 @@ public class APIEndpoint {
             service.post("/extract/end", new EndExtractionHandler());
             service.post("/extract/start", new StartExtractionHandler());
         });
+        service.post(makePath("extractFiles"), new FileExtractionHandler());
         if (Config.sharedConfig().getApi().getServeContent()) {
           service.path(makePath("get"), () -> {
             service.get("/thumbnails/:id", new ResolvedContentRoute(

--- a/src/org/vitrivr/cineast/api/SessionExtractionContainer.java
+++ b/src/org/vitrivr/cineast/api/SessionExtractionContainer.java
@@ -13,6 +13,7 @@ import org.vitrivr.cineast.core.run.ExtractionDispatcher;
 import org.vitrivr.cineast.core.run.ExtractionItemContainer;
 import org.vitrivr.cineast.core.run.path.SessionContainerProvider;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
+import org.vitrivr.cineast.core.data.MediaType;
 
 /**
  * Singleton Structure. Intended to be an access points across multiple sessions. Can be closed and
@@ -60,7 +61,6 @@ public class SessionExtractionContainer {
             "Could not start session with configuration file '%s'. Does the file exist?",
             configFile.toString()));
       }
-      dispatcher.start();
     } catch (IOException e) {
       System.err.println(String.format(
           "Could not start session with configuration file '%s' due to a IO error.",
@@ -76,6 +76,24 @@ public class SessionExtractionContainer {
     getProviderOrExit().close();
     LOGGER.debug("Restarting SessionPathProvider");
     initalizeExtraction();
+  }
+
+  public static void startSessionFor(MediaType mediaType) {
+    configFile = getConfigFileForMediaType(mediaType);
+    if (provider != null) {
+      getProviderOrExit().close();
+    }
+    initalizeExtraction();
+  }
+
+  public static File getConfigFileForMediaType(MediaType mediaType) {
+    switch (mediaType) {
+      case IMAGE: return new File("image_extraction_config.json");
+      case VIDEO: return new File("video_extraction_config.json");
+      case AUDIO: return new File("audio_extraction_config.json");
+      case MODEL3D: return new File("3dmodel_extraction_config.json");
+    }
+    return null;
   }
 
   public static void close() {
@@ -101,7 +119,11 @@ public class SessionExtractionContainer {
    * @return if the underlying provider is closed
    */
   public static boolean keepAliveCheckIfClosed() {
-    return getOpenProviderOrExit().keepAliveCheckIfClosed();
+    return getProviderOrExit().keepAliveCheckIfClosed();
+  }
+
+  public static boolean isProviderNull() {
+    return provider == null;
   }
 
   private static SessionContainerProvider getProviderOrExit() {

--- a/src/org/vitrivr/cineast/api/rest/handlers/actions/FileExtractionHandler.java
+++ b/src/org/vitrivr/cineast/api/rest/handlers/actions/FileExtractionHandler.java
@@ -1,0 +1,160 @@
+package org.vitrivr.cineast.api.rest.handlers.actions;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.vitrivr.cineast.api.SessionExtractionContainer;
+import org.vitrivr.cineast.core.data.messages.session.ExtractionContainerMessage;
+import org.vitrivr.cineast.api.SessionExtractionContainer;
+import org.vitrivr.cineast.core.run.ExtractionItemContainer;
+import org.vitrivr.cineast.core.data.entities.MultimediaObjectDescriptor;
+import org.vitrivr.cineast.core.data.MediaType;
+import org.vitrivr.cineast.core.config.Config;
+import spark.Route;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import spark.Request;
+import spark.Response;
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.http.Part;
+import java.io.File;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * @author iammvaibhav on 06.07.18
+ * @version 1.0
+ *
+ * This handler is used to let the users upload media files to be extracted along with a extract.json
+ * file which will be deserialized to ExtractionContainerMessage and will be passed to extraction pipeline for
+ * media extraction.
+ *
+ * File are uploaded using the enctype multipart/form-data.
+ */
+public class FileExtractionHandler implements Route {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  /**
+   * Jackson ObjectMapper used to map to/from objects.
+   */
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /* Can be used to setup the ObjectMapper.  */
+  static {
+      MAPPER.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+      MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      MAPPER.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
+  }
+
+
+  @Override
+  public Object handle(Request request, Response response) throws Exception {
+
+    request.raw().setAttribute("org.eclipse.jetty.multipartConfig", new MultipartConfigElement("/temp"));
+
+    ExtractionContainerMessage extractionContainerMessage = null;
+
+    Part config = request.raw().getPart("extract_config");
+    if (config != null) {
+      extractionContainerMessage = MAPPER.readValue(config.getInputStream(), ExtractionContainerMessage.class);
+    } else return "extract_config key not found";
+
+    if (extractionContainerMessage == null)
+      return "malformed extraction config message";
+
+    MediaType mediaType;
+    try {
+        mediaType = MediaType.valueOf(request.headers("media_type"));
+    } catch (Exception e) {
+      return "error occured in decoding media_type value";
+    }
+
+    /**
+     * Get all the files from HTTP multipart request and store them in the
+     * appropriate media folders in the object location
+     */
+    for (ExtractionItemContainer itemContainer: extractionContainerMessage.getItems()) {
+      String fileName = itemContainer.getObject().getName();
+
+      File inputFile = getFile(fileName, extractionContainerMessage);
+      Path filePath = inputFile.toPath();
+
+      itemContainer.setPath(Paths.get(inputFile.toURI()));
+
+      if (request.raw().getPart(fileName) != null) {
+        try (InputStream input = request.raw().getPart(fileName).getInputStream()) {
+            // Use the input stream to create a file
+            Files.copy(input, filePath, StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    }
+
+    // start the session
+    if (SessionExtractionContainer.isProviderNull()) {
+      SessionExtractionContainer.open(SessionExtractionContainer.getConfigFileForMediaType(mediaType));
+    } else if (!SessionExtractionContainer.isProviderNull() && SessionExtractionContainer.keepAliveCheckIfClosed()) {
+      SessionExtractionContainer.startSessionFor(mediaType);
+    }
+
+    // add to extraction pipeline
+    SessionExtractionContainer.addPaths(extractionContainerMessage.getItems());
+
+    // end the session
+    SessionExtractionContainer.endSession();
+
+    return "Files submitted for extraction";
+  }
+
+  /**
+   * given Part object, this method return the file name
+   * @param part part of request describing a file
+   * @return file name
+   */
+  private String getFileName(Part part) {
+    for (String cd : part.getHeader("content-disposition").split(";")) {
+      if (cd.trim().startsWith("filename")) {
+        return cd.substring(cd.indexOf('=') + 1).trim().replace("\"", "");
+      }
+    }
+    return null;
+  }
+
+  /**
+   * given a file name and ExtractionContainerMessage, returns the File object
+   * representing object location according to media type
+   */
+  private File getFile(String fileName, ExtractionContainerMessage extractionContainerMessage) {
+
+    for (ExtractionItemContainer itemContainer: extractionContainerMessage.getItems()) {
+      if (fileName.equals(itemContainer.getObject().getName())) {
+        int mediatypeId = itemContainer.getObject().getMediatypeId();
+
+        String mediaType = null;
+
+        switch (mediatypeId) {
+          case 0: mediaType = "video"; break;
+          case 1: mediaType = "image"; break;
+          case 2: mediaType = "audio"; break;
+          case 3: mediaType = "model3d"; break;
+          default: mediaType = null;
+        }
+
+        if (mediaType == null) {
+          return null;
+        }
+
+        File mediaFolder = new File(Config.sharedConfig().getApi().getObjectLocation(), mediaType);
+        mediaFolder.mkdirs();
+        return new File(mediaFolder, fileName);
+      }
+    }
+    return null;
+  }
+}

--- a/src/org/vitrivr/cineast/core/run/ExtractionItemContainer.java
+++ b/src/org/vitrivr/cineast/core/run/ExtractionItemContainer.java
@@ -40,6 +40,10 @@ public class ExtractionItemContainer {
     return path;
   }
 
+  public void setPath(Path path) {
+    this.path = path;
+  }
+
   public void setObject(MultimediaObjectDescriptor object) {
     this.object = object;
   }


### PR DESCRIPTION
Add Media API is completely implemented. This implementation is different from the one I did previously. Main highlights are:

1) No need to start the cineast server with --server option along with a config file. When a request arrives, provider will be initialized/opened if closed, extraction will take place and then session will be ended so as to write data to ADAMPro.

2) Instead of starting cineast server with --server config, there must be 4 config files (for image, video, audio, 3d model) in the same directory as cineast.jar. This is done mainly because of three reasons.
i. If there is only one config files, all the exporters need to be specified (ShotThumbNails, AudioWaveformExporter, Model3DThumbnailExporter etc) for all different media types. The problem with this is if say an image is getting processed, and if AudioWaveformExporter is specified, it will process and export the waveform even though it doesn't make any sense for an image. 
ii. In case of single config files, only a single set of extractors can be specified for all types even when say LightfieldZernike doesn't make any sense while extracting an image. This doesn't necessary creates any problem except taking some extra time in checking. When using multiple configs, different set of extractors can be specified for different media types. 
iii. In case two or more media type uses a same exporter (ex both IMAGE and VIDEO can use ShotThumbNails) then they will be exported to the same directory (which is specified in config). This creates problems when retrieving thumbnails in current client scenario which expects thumbnails of different media types to be in different directories. When using multiple config files, this problem will also be solved.
Also if required, request can specify the extractors and exporters to be used while extraction. This isn't implemented yet as I'm not very sure about it's utility.
The current implementation requires image_extraction_config.json, video_extraction_config.json, audio_extarction_config.json, and 3dmodel_extraction_config.json in the same directory as cineast.jar each having input (for Unique id generator), extractors and exporters block.

3) Users can upload mutiple files at once of the SAME type (viz IMAGE, VIDEO, AUDIO, MODEL3D) along with the metadata if any. Specifically
i. Request will be of type multipart/form-data.
ii. A header media_type needs to be specified which tells the media type of all the files.
iii. files to be extracted should be uploaded with filename as their key.
iv. A key extract_config should be specified along with the file which will be deserialized to 'ExtractionItemContainer'.
v. In the object section of ExtractionItemContainer, name and path fields should be set to file name and uri can be any valid dummy uri (because of URI validations eg file:///dummy)

4) Valid objectlocation needs to be specified in api section of cineast.json. The uploaded files will be segregated according to their media types so as to comply with the current client specifications.