### PR TITLE
Restored consistency in certain query responses

### DIFF
--- a/src/org/vitrivr/cineast/api/rest/handlers/actions/FindMetadataByObjectIdActionHandler.java
+++ b/src/org/vitrivr/cineast/api/rest/handlers/actions/FindMetadataByObjectIdActionHandler.java
@@ -4,6 +4,7 @@ import org.vitrivr.cineast.api.rest.handlers.abstracts.ParsingActionHandler;
 import org.vitrivr.cineast.core.data.entities.MultimediaMetadataDescriptor;
 import org.vitrivr.cineast.core.data.entities.MultimediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.messages.lookup.IdList;
+import org.vitrivr.cineast.core.data.messages.result.MetadataQueryResult;
 import org.vitrivr.cineast.core.db.dao.reader.MultimediaMetadataReader;
 
 import java.util.ArrayList;
@@ -21,15 +22,15 @@ public class FindMetadataByObjectIdActionHandler extends ParsingActionHandler<Id
      * Processes a HTTP GET request.
      *
      * @param parameters Map containing named parameters in the URL.
-     * @return List of {@link MultimediaObjectDescriptor}s
+     * @return {@link MetadataQueryResult}
      */
     @Override
-    public List<MultimediaMetadataDescriptor> doGet(Map<String, String> parameters) {
+    public MetadataQueryResult doGet(Map<String, String> parameters) {
         final String objectId = parameters.get(ATTRIBUTE_ID);
         final MultimediaMetadataReader reader = new MultimediaMetadataReader();
         final List<MultimediaMetadataDescriptor> descriptors = reader.lookupMultimediaMetadata(objectId);
         reader.close();
-        return descriptors;
+        return new MetadataQueryResult("", descriptors);
     }
 
     /**
@@ -37,17 +38,17 @@ public class FindMetadataByObjectIdActionHandler extends ParsingActionHandler<Id
      *
      * @param context Object that is handed to the invocation, usually parsed from the request body. May be NULL!
      * @param parameters Map containing named parameters in the URL.
-     * @return List of {@link MultimediaObjectDescriptor}s
+     * @return {@link MetadataQueryResult}
      */
     @Override
-    public List<MultimediaMetadataDescriptor> doPost(IdList context, Map<String, String> parameters) {
+    public MetadataQueryResult doPost(IdList context, Map<String, String> parameters) {
         if(context == null || context.getIds().length == 0 ){
-            return new ArrayList<>(0);
+            return new MetadataQueryResult("", new ArrayList<>(0) );
         }
         final MultimediaMetadataReader reader = new MultimediaMetadataReader();
         final List<MultimediaMetadataDescriptor> descriptors = reader.lookupMultimediaMetadata(context.getIdList());
         reader.close();
-        return descriptors;
+        return new MetadataQueryResult("",descriptors);
     }
 
     /**

--- a/src/org/vitrivr/cineast/api/rest/handlers/actions/FindObjectByActionHandler.java
+++ b/src/org/vitrivr/cineast/api/rest/handlers/actions/FindObjectByActionHandler.java
@@ -1,20 +1,17 @@
 package org.vitrivr.cineast.api.rest.handlers.actions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.api.rest.handlers.abstracts.ParsingActionHandler;
 import org.vitrivr.cineast.core.data.entities.MultimediaObjectDescriptor;
-import org.vitrivr.cineast.core.data.messages.general.AnyMessage;
 import org.vitrivr.cineast.core.data.messages.lookup.IdList;
 import org.vitrivr.cineast.core.data.messages.result.ObjectQueryResult;
 import org.vitrivr.cineast.core.db.dao.reader.MultimediaObjectLookup;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * @author rgasser
@@ -35,7 +32,7 @@ public class FindObjectByActionHandler extends ParsingActionHandler<IdList> {
      * @return {@link ObjectQueryResult}
      */
     @Override
-    public List<MultimediaObjectDescriptor> doGet(Map<String, String> parameters) {
+    public ObjectQueryResult doGet(Map<String, String> parameters) {
         String attribute = parameters.get(ATTRIBUTE_NAME);
         String value = parameters.get(VALUE_NAME);
 
@@ -61,7 +58,7 @@ public class FindObjectByActionHandler extends ParsingActionHandler<IdList> {
         }
 
         ol.close();
-        return Lists.newArrayList(object);
+        return new ObjectQueryResult("",Lists.newArrayList(object));
     }
 
     /**
@@ -71,14 +68,14 @@ public class FindObjectByActionHandler extends ParsingActionHandler<IdList> {
      * @return {@link ObjectQueryResult}
      */
     @Override
-    public List<MultimediaObjectDescriptor> doPost(IdList context, Map<String, String> parameters) {
+    public ObjectQueryResult doPost(IdList context, Map<String, String> parameters) {
         if(context == null || context.getIds().length == 0){
-            return new ArrayList<>(0);
+            return new ObjectQueryResult("",new ArrayList<>(0));
         }
         final MultimediaObjectLookup ol = new MultimediaObjectLookup();
         final Map<String, MultimediaObjectDescriptor> objects = ol.lookUpObjects(Arrays.asList(context.getIds()));
         ol.close();
-        return new ArrayList<>(objects.values());
+        return new ObjectQueryResult("",new ArrayList<>(objects.values()));
     }
 
     @Override

--- a/src/org/vitrivr/cineast/api/rest/handlers/actions/FindSegmentsByIdActionHandler.java
+++ b/src/org/vitrivr/cineast/api/rest/handlers/actions/FindSegmentsByIdActionHandler.java
@@ -1,12 +1,15 @@
 package org.vitrivr.cineast.api.rest.handlers.actions;
 
-import java.util.*;
-
 import org.vitrivr.cineast.api.rest.handlers.abstracts.ParsingActionHandler;
 import org.vitrivr.cineast.core.data.entities.SegmentDescriptor;
 import org.vitrivr.cineast.core.data.messages.lookup.IdList;
-import org.vitrivr.cineast.core.data.messages.result.ObjectQueryResult;
+import org.vitrivr.cineast.core.data.messages.result.SegmentQueryResult;
 import org.vitrivr.cineast.core.db.dao.reader.SegmentLookup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class FindSegmentsByIdActionHandler extends ParsingActionHandler<IdList> {
 
@@ -16,10 +19,10 @@ public class FindSegmentsByIdActionHandler extends ParsingActionHandler<IdList> 
      * Processes a HTTP GET request.
      *
      * @param parameters Map containing named parameters in the URL.
-     * @return {@link ObjectQueryResult}
+     * @return {@link SegmentQueryResult}
      */
     @Override
-    public Object doGet(Map<String, String> parameters) {
+    public SegmentQueryResult doGet(Map<String, String> parameters) {
         final String segmentId = parameters.get(ID_NAME);
         final SegmentLookup sl = new SegmentLookup();
         final List<SegmentDescriptor> list = sl.lookUpSegment(segmentId).map(s -> {
@@ -28,7 +31,7 @@ public class FindSegmentsByIdActionHandler extends ParsingActionHandler<IdList> 
             return segments;
         }).orElse(new ArrayList<>(0));
         sl.close();
-        return list;
+        return new SegmentQueryResult("",list);
     }
 
     /**
@@ -36,17 +39,17 @@ public class FindSegmentsByIdActionHandler extends ParsingActionHandler<IdList> 
      *
      * @param context Object that is handed to the invocation, usually parsed from the request body. May be NULL!
      * @param parameters Map containing named parameters in the URL.
-     * @return List of {@link SegmentDescriptor}s
+     * @return SegmentQueryResult
      */
     @Override
-    public List<SegmentDescriptor> doPost(IdList context, Map<String, String> parameters) {
+    public SegmentQueryResult doPost(IdList context, Map<String, String> parameters) {
         if (context == null || context.getIds().length == 0) {
-            return new ArrayList<>(0);
+            return new SegmentQueryResult("",new ArrayList<>(0));
         }
         final SegmentLookup sl = new SegmentLookup();
         final Map<String, SegmentDescriptor> segments = sl.lookUpSegments(Arrays.asList(context.getIds()));
         sl.close();
-        return new ArrayList<>(segments.values());
+        return new SegmentQueryResult("", new ArrayList<>(segments.values())) ;
     }
 
     @Override


### PR DESCRIPTION
TL;DR Websocket and RESTful API now respond with the same JSON object's and lists are properly enclosed by an object.

The following is a copy of  sauterl/cineast@940f74c2ee13d78b8427c3de214e611189e23249 describing the consequences of the change:

---

Restored consistency in certain query responses

The WebSocket and RESTful API now returns the same JSON objects for

 * /find/metadata/by/id
 * /find/objects/by/id
 * /find/segments/by/id

Each of the corresponding RESTful action handler's now do have the same result
type as the corresponding WebSocket handlers have.

The main advantage is that both APIs do now have similar response
objects.
Further, there is a minor advantage in not sending top level arrays: A
few JSON processors cannot handle such documents and would therefore not
be able to be used in a cineast context.
