### PR TITLE
Added response header in RESTful API to allow all headers

### DIFF
--- a/src/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/src/org/vitrivr/cineast/api/APIEndpoint.java
@@ -113,6 +113,7 @@ public class APIEndpoint {
         /* Configure the result after processing was completed. */
         service.after((request, response) -> {
             response.header("Access-Control-Allow-Origin", "*");
+            response.header("Access-Control-Allow-Headers", "*");
         });
 
         return service;


### PR DESCRIPTION
Added `Access-Control-Allow-Headers: *` explicitely to the header in RESTful API.

In some circumstances of asnchronous calls, at least Google Chrome probes access control and requires this header to perform POST requests to the RESTful API.