### PR TITLE
avoid getting first k of batched knn only

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
@@ -87,7 +87,7 @@ public class CottontailSelector implements DBSelector {
             vectors,
             null,
             k,
-            configs.get(0).getDistance().orElse(Distance.manhattan)), k);
+            configs.get(0).getDistance().orElse(Distance.manhattan)), null);
 
     List<QueryResponseMessage> results = this.cottontail.query(CottontailMessageBuilder.queryMessage(query, configs.get(0).getQueryId().toString()));
 


### PR DESCRIPTION
A batched knn query is designed to return k*n results. Til now, k was set as query limit, so we always got the k nearest neighbours of the first provided segment only.