### PR TITLE
Fixed OpenAPI route specifications not being documented properly

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
@@ -310,7 +310,7 @@ public class APIEndpoint {
             return OpenApiBuilder.moveDocumentationFromAnnotationToHandler(method, javalinHandler);
         } catch (NoSuchMethodException | SecurityException e) {
             throw new IllegalArgumentException("The given handler of type "+restHandler.getClass()+" has no " + implMethodName + "(Context) method", e);
-	    }
+        }
     }
     
     private void registerRestOperations(){

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
@@ -305,12 +305,12 @@ public class APIEndpoint {
      * @return Documented handler or the input handler if no annotation is present
      */
     private Handler documentHandler(final RestHandler restHandler, final Handler javalinHandler, final String implMethodName) {
-    	try {
-			Method method = restHandler.getClass().getMethod(implMethodName, Context.class);
-			return OpenApiBuilder.moveDocumentationFromAnnotationToHandler(method, javalinHandler);
-    	} catch (NoSuchMethodException | SecurityException e) {
-			throw new IllegalArgumentException("The given handler of type "+restHandler.getClass()+" has no " + implMethodName + "(Context) method", e);
-		}
+        try {
+            Method method = restHandler.getClass().getMethod(implMethodName, Context.class);
+            return OpenApiBuilder.moveDocumentationFromAnnotationToHandler(method, javalinHandler);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalArgumentException("The given handler of type "+restHandler.getClass()+" has no " + implMethodName + "(Context) method", e);
+	    }
     }
     
     private void registerRestOperations(){


### PR DESCRIPTION
Just a small change so that the OpenAPI route specifications documentation works again. Since the `@OpenApi` annotation is applied to the implementation methods (`doGet/doPut/etc.`) the documentation data needs to be copied from that annotation to the actual handlers (`get/put/etc.`), so that the Javalin OpenAPI plugin can know about it.