### PR TITLE
Allow extraction config to be passed to specify database entities to setup

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/DatabaseSetupCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/DatabaseSetupCommand.java
@@ -3,11 +3,23 @@ package org.vitrivr.cineast.standalone.cli;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashSet;
+
+import org.vitrivr.cineast.core.db.PersistentOperator;
 import org.vitrivr.cineast.core.db.setup.EntityCreator;
 import org.vitrivr.cineast.core.features.retriever.Retriever;
+import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 import org.vitrivr.cineast.standalone.config.Config;
+import org.vitrivr.cineast.standalone.config.ExtractorConfig;
+import org.vitrivr.cineast.standalone.config.IngestConfig;
+import org.vitrivr.cineast.standalone.run.ExtractionCompleteListener;
+import org.vitrivr.cineast.standalone.run.ExtractionContainerProvider;
+import org.vitrivr.cineast.standalone.run.path.ExtractionContainerProviderFactory;
 
 /**
  * A CLI command that can be used to setup all the database entities required by Cineast.
@@ -21,19 +33,47 @@ public class DatabaseSetupCommand implements Runnable {
   @Option(name = {"-c", "--clean"}, description = "Performs a cleanup before starting the setup; i.e. explicitly drops all entities.")
   private boolean clean = false;
 
+  @Option(name = {"-e", "--extraction"}, title = "Extraction config", description = "If specified, setup database based upon Cineast extraction config file.")
+  private String extractionConfig = null;
+
+  private HashSet<PersistentOperator> configPersistentOperators() {
+    /* Collects all the relevant retriever classes based on the application config. */
+    final HashSet<PersistentOperator> persistentOperators = new HashSet<>();
+    for (String category : Config.sharedConfig().getRetriever().getRetrieverCategories()) {
+      persistentOperators.addAll(Config.sharedConfig().getRetriever().getRetrieversByCategory(category).keySet());
+    }
+    return persistentOperators;
+  }
+
+  private HashSet<PersistentOperator> extractionConfigPersistentOperators(String extractionConfig) {
+    final HashSet<PersistentOperator> persistentOperators = new HashSet<>();
+    final File file = new File(extractionConfig);
+    if (file.exists()) {
+      final JacksonJsonProvider reader = new JacksonJsonProvider();
+      final IngestConfig context = reader.toObject(file, IngestConfig.class);
+      for (ExtractorConfig extractor : context.getExtractors()) {
+        persistentOperators.add(extractor.getExtractor());
+      }
+    } else {
+      System.err.println(String.format("Could not setup database based upon extraction config '%s'; the file does not exist!", file.toString()));
+    }
+    return persistentOperators;
+}
+
   @Override
   public void run() {
     final EntityCreator ec = Config.sharedConfig().getDatabase().getEntityCreatorSupplier().get();
     if (ec != null) {
-      /* Collects all the relevant retriever classes based on the application config. */
-      final HashSet<Retriever> retrievers = new HashSet<>();
-      for (String category : Config.sharedConfig().getRetriever().getRetrieverCategories()) {
-        retrievers.addAll(Config.sharedConfig().getRetriever().getRetrieversByCategory(category).keySet());
+      HashSet<PersistentOperator> persistentOperators;
+      if (this.extractionConfig == null) {
+        persistentOperators = this.configPersistentOperators();
+      } else {
+        persistentOperators = this.extractionConfigPersistentOperators(this.extractionConfig);
       }
 
       System.out.println(clean);
       if (this.clean) {
-        this.dropAllEntities(ec, retrievers);
+        this.dropAllEntities(ec, persistentOperators);
       }
 
       System.out.println("Setting up basic entities...");
@@ -48,7 +88,7 @@ public class DatabaseSetupCommand implements Runnable {
 
       System.out.println("Setting up retriever classes...");
 
-      for (Retriever r : retrievers) {
+      for (PersistentOperator r : persistentOperators) {
         System.out.println("Creating entity for " + r.getClass().getSimpleName());
         r.initalizePersistentLayer(() -> ec);
       }
@@ -67,7 +107,7 @@ public class DatabaseSetupCommand implements Runnable {
    * @param ec The {@link EntityCreator} used to drop the entities.
    * @param retrievers The list of {@link Retriever} classes to drop the entities for.
    */
-  private void dropAllEntities(EntityCreator ec, Collection<Retriever> retrievers) {
+  private void dropAllEntities(EntityCreator ec, Collection<PersistentOperator> persistentOperators) {
     System.out.println("Dropping all entities... ");
     ec.dropMultiMediaObjectsEntity();
     ec.dropMetadataEntity();
@@ -75,9 +115,9 @@ public class DatabaseSetupCommand implements Runnable {
     ec.dropSegmentMetadataEntity();
     ec.dropTagEntity();
 
-    for (Retriever r : retrievers) {
-      System.out.println("Dropping " + r.getClass().getSimpleName());
-      r.dropPersistentLayer(() -> ec);
+    for (PersistentOperator p : persistentOperators) {
+      System.out.println("Dropping " + p.getClass().getSimpleName());
+      p.dropPersistentLayer(() -> ec);
     }
   }
 }


### PR DESCRIPTION
This patch allows --extraction to be passed to setup to setup tables/entities from the extraction json instead of the cineast json, which could be convenient e.g. if you're doing a batch extraction of many features and you might expose a subset later on.