### PR TITLE
Add relTo, allow file inputPath in extraction config

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
@@ -40,6 +40,17 @@ public interface ExtractionContextProvider {
   Optional<Path> inputPath();
 
   /**
+   * Gives a path to which inputPath, and all output path references are relative to.
+   * Intended for running multiple instances of the extraction process on different parts of a
+   * collection.
+   *
+   * @return Path to the relative parent of inputPath
+   */
+  default Optional<Path> relPath() {
+    return Optional.empty();
+  }
+
+  /**
    * Limits the number of files that should be extracted. This a predicate is applied before
    * extraction starts. If extraction fails for some fails the effective number of extracted files
    * may be lower.

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
@@ -192,6 +192,14 @@ public final class IngestConfig implements ExtractionContextProvider {
         }
     }
 
+    @Override
+    public Optional<Path> relPath() {
+        if (this.input == null || this.input.getRelTo() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Paths.get(this.input.getRelTo()));
+    }
+
     public ExtractionContainerProvider pathProvider() {
         if (this.input != null) {
             return new SingletonContainerProvider(Paths.get(this.input.getPath()));

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
@@ -11,6 +11,7 @@ import org.vitrivr.cineast.core.config.IdConfig;
 public class InputConfig {
     private String path;
     private String name;
+    private String relTo;
     private Integer depth = 1;
 
     private Integer skip = 0;
@@ -31,6 +32,14 @@ public class InputConfig {
     }
     public void setPath(String path) {
         this.path = path;
+    }
+
+    @JsonProperty(required = true)
+    public String getRelTo() {
+        return relTo;
+    }
+    public void setRelTo(String relTo) {
+        this.relTo = relTo;
     }
 
     @JsonProperty

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/path/ExtractionContainerProviderFactory.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/path/ExtractionContainerProviderFactory.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.standalone.run.path;
 
+import java.nio.file.Paths;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.extraction.ExtractionContextProvider;
@@ -29,15 +30,25 @@ public class ExtractionContainerProviderFactory {
     if (!context.inputPath().isPresent()) {
       return new NoContainerProvider();
     }
-    Path path = jobDirectory.resolve(context.inputPath().get()).normalize().toAbsolutePath();
+    Path inputPath = context.inputPath().get();
+    Path basePath;
+    Path startPath;
+    if (context.relPath().isPresent()) {
+      basePath = context.relPath().get();
+      startPath = inputPath;
+    } else {
+      basePath = inputPath;
+      startPath = Paths.get("");
+    }
+    basePath = jobDirectory.resolve(basePath).normalize().toAbsolutePath();
 
-    if (!Files.exists(path)) {
+    if (!Files.exists(basePath)) {
       LOGGER.warn("The path '{}' specified in the extraction configuration does not exist!",
-          path.toString());
+          basePath.toString());
       return new NoContainerProvider();
     }
 
-    return new TreeWalkContainerIteratorProvider(path, context);
+    return new TreeWalkContainerIteratorProvider(basePath, startPath, context.depth());
   }
 
 }


### PR DESCRIPTION
This helps with usage in which the extraction process is invoked multiple times for each file within a larger collection -- typically by templating the extraction config file.