### PR TITLE
Extraction improvements

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
@@ -1,19 +1,18 @@
 package org.vitrivr.cineast.core.extraction;
 
-import org.vitrivr.cineast.core.config.IdConfig;
-import org.vitrivr.cineast.core.config.CacheConfig;
-import org.vitrivr.cineast.core.data.MediaType;
-import org.vitrivr.cineast.core.db.DBSelectorSupplier;
-import org.vitrivr.cineast.core.db.PersistencyWriterSupplier;
-import org.vitrivr.cineast.core.extraction.idgenerator.ObjectIdGenerator;
-import org.vitrivr.cineast.core.extraction.segmenter.general.Segmenter;
-import org.vitrivr.cineast.core.features.extractor.Extractor;
-import org.vitrivr.cineast.core.extraction.metadata.MetadataExtractor;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import org.vitrivr.cineast.core.config.CacheConfig;
+import org.vitrivr.cineast.core.config.IdConfig;
+import org.vitrivr.cineast.core.data.MediaType;
+import org.vitrivr.cineast.core.db.DBSelectorSupplier;
+import org.vitrivr.cineast.core.db.PersistencyWriterSupplier;
+import org.vitrivr.cineast.core.extraction.idgenerator.ObjectIdGenerator;
+import org.vitrivr.cineast.core.extraction.metadata.MetadataExtractor;
+import org.vitrivr.cineast.core.extraction.segmenter.general.Segmenter;
+import org.vitrivr.cineast.core.features.extractor.Extractor;
 
 /**
  * Provides a configuration context for an extraction run.
@@ -25,8 +24,7 @@ import java.util.Optional;
 public interface ExtractionContextProvider {
 
   /**
-   * Determines the MediaType of the source material. Only one media-type can be specified per
-   * ExtractionContextProvider.
+   * Determines the MediaType of the source material. Only one media-type can be specified per ExtractionContextProvider.
    *
    * @return Media-type of the source material.
    */
@@ -40,8 +38,16 @@ public interface ExtractionContextProvider {
   Optional<Path> inputPath();
 
   /**
-   * Limits the depth of recursion when extraction folders of files. Has no effect if the inputPath
-   * points to a file.
+   * Gives a path to which inputPath, and all output path references are relative to. Intended for running multiple instances of the extraction process on different parts of a collection.
+   *
+   * @return Path to the relative parent of inputPath
+   */
+  default Optional<Path> relPath() {
+    return Optional.empty();
+  }
+
+  /**
+   * Limits the depth of recursion when extraction folders of files. Has no effect if the inputPath points to a file.
    *
    * @return A number greater than zero.
    */
@@ -55,33 +61,28 @@ public interface ExtractionContextProvider {
   List<Extractor> extractors();
 
   /**
-   * Returns a list of exporter classes that should be invoked during extraction. Exporters usually
-   * generate some representation and persistently store that information somewhere.
+   * Returns a list of exporter classes that should be invoked during extraction. Exporters usually generate some representation and persistently store that information somewhere.
    *
    * @return List of named exporters.
    */
   List<Extractor> exporters();
 
   /**
-   * Returns a list of metadata extractor classes that should be invoked during extraction.
-   * MetadataExtractor's usually read some metadata from a file.
+   * Returns a list of metadata extractor classes that should be invoked during extraction. MetadataExtractor's usually read some metadata from a file.
    *
    * @return List of named exporters.
    */
   List<MetadataExtractor> metadataExtractors();
 
   /**
-   * Selects, configures and returns a new instance of the {@link Segmenter} that was configured in
-   * the current instance of {@link ExtractionContextProvider}.
+   * Selects, configures and returns a new instance of the {@link Segmenter} that was configured in the current instance of {@link ExtractionContextProvider}.
    *
-   * @return {@link Segmenter} that was configured in the current instance of {@link
-   * ExtractionContextProvider}
+   * @return {@link Segmenter} that was configured in the current instance of {@link ExtractionContextProvider}
    */
   <T> Segmenter<T> newSegmenter();
 
   /**
-   * Returns an instance of ObjectIdGenerator that should be used to generated MultimediaObject ID's
-   * during an extraction run.
+   * Returns an instance of ObjectIdGenerator that should be used to generated MultimediaObject ID's during an extraction run.
    *
    * @return ObjectIdGenerator
    */
@@ -101,25 +102,21 @@ public interface ExtractionContextProvider {
   IdConfig.ExistenceCheck existenceCheck();
 
   /**
-   * Returns the PersistencyWriterSupplier that can be used during the extraction run to obtain
-   * PersistencyWriter instance.
+   * Returns the PersistencyWriterSupplier that can be used during the extraction run to obtain PersistencyWriter instance.
    *
    * @return PersistencyWriterSupplier instance used obtain a PersistencyWriter.
    */
   PersistencyWriterSupplier persistencyWriter();
 
   /**
-   * Returns the DBSelectorSupplier that can be used during the extraction run to obtain a
-   * DBSelector instance.
+   * Returns the DBSelectorSupplier that can be used during the extraction run to obtain a DBSelector instance.
    *
    * @return DBSelectorSupplier instance used obtain a DBSelector.
    */
   DBSelectorSupplier persistencyReader();
 
   /**
-   * Returns the default output-location for files generated during extraction (e.g. thumbnails,
-   * PROTO files etc.). Unless explicitly stated otherwise in the configuration of one of the
-   * exporters, this path will be used.
+   * Returns the default output-location for files generated during extraction (e.g. thumbnails, PROTO files etc.). Unless explicitly stated otherwise in the configuration of one of the exporters, this path will be used.
    *
    * @return Output location for files generated during extraction.
    */
@@ -133,16 +130,14 @@ public interface ExtractionContextProvider {
   int threadPoolSize();
 
   /**
-   * Returns the size of the task queue. That queue is used to store extraction tasks right before
-   * they are being processed.
+   * Returns the size of the task queue. That queue is used to store extraction tasks right before they are being processed.
    *
    * @return Size of the task queue. Must be > 0.
    */
   Integer taskQueueSize();
 
   /**
-   * Returns the size of the segment queue. That queue is used to store segments when they are
-   * handed to the extraction pipeline but the pipeline is currently fully occupied.
+   * Returns the size of the segment queue. That queue is used to store segments when they are handed to the extraction pipeline but the pipeline is currently fully occupied.
    *
    * @return Size of the segment queue. Must be > 0.
    */
@@ -150,8 +145,7 @@ public interface ExtractionContextProvider {
 
 
   /**
-   * Returns the size of a batch. A batch is used when persisting data. Entities will be kept in
-   * memory until the batchsize limit is hit at which point they will be persisted.
+   * Returns the size of a batch. A batch is used when persisting data. Entities will be kept in memory until the batchsize limit is hit at which point they will be persisted.
    *
    * @return Batch size.
    */

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
@@ -40,24 +40,6 @@ public interface ExtractionContextProvider {
   Optional<Path> inputPath();
 
   /**
-   * Limits the number of files that should be extracted. This a predicate is applied before
-   * extraction starts. If extraction fails for some fails the effective number of extracted files
-   * may be lower.
-   *
-   * @return A number greater than zero.
-   */
-  @Deprecated
-  int limit();
-
-  /**
-   * Offset into the list of files that are being distracted.
-   *
-   * @return A positive number or zero
-   */
-  @Deprecated
-  int skip();
-
-  /**
    * Limits the depth of recursion when extraction folders of files. Has no effect if the inputPath
    * points to a file.
    *

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/ExtractionContextProvider.java
@@ -30,7 +30,7 @@ public interface ExtractionContextProvider {
    *
    * @return Media-type of the source material.
    */
-  MediaType sourceType();
+  MediaType getType();
 
   /**
    * Determines the path of the input-file or folder.

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
@@ -143,11 +143,6 @@ public final class IngestConfig implements ExtractionContextProvider {
         this.cacheConfig = cacheConfig;
     }
 
-    @JsonProperty
-    public MediaType getType() {
-        return type;
-    }
-
     @JsonProperty(required = true)
     public InputConfig getInput() {
         return input;
@@ -207,7 +202,8 @@ public final class IngestConfig implements ExtractionContextProvider {
      * @return Media-type of the source material.
      */
     @Override
-    public MediaType sourceType() {
+    @JsonProperty
+    public MediaType getType() {
         return this.type;
     }
 

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
@@ -275,30 +275,6 @@ public final class IngestConfig implements ExtractionContextProvider {
     }
 
     /**
-     * Offset into the list of files that are being distracted.
-     *
-     * @return A positive number or zero
-     */
-    @Override
-    @Deprecated
-    public int skip() {
-        return this.input.getSkip();
-    }
-
-    /**
-     * Limits the number of files that should be extracted. This a predicate is applied
-     * before extraction starts. If extraction fails for some fails the effective number
-     * of extracted files may be lower.
-     *
-     * @return A number greater than zero.
-     */
-    @Override
-    @Deprecated
-    public int limit() {
-        return this.input.getLimit();
-    }
-
-    /**
      * Returns an instance of ObjectIdGenerator that should be used to generated MultimediaObject ID's
      * during an extraction run.
      *

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
@@ -187,6 +187,14 @@ public final class IngestConfig implements ExtractionContextProvider {
         }
     }
 
+    @Override
+    public Optional<Path> relPath() {
+        if (this.input == null || this.input.getRelTo() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Paths.get(this.input.getRelTo()));
+    }
+
     public ExtractionContainerProvider pathProvider() {
         if (this.input != null) {
             return new SingletonContainerProvider(Paths.get(this.input.getPath()));

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/IngestConfig.java
@@ -285,10 +285,6 @@ public final class IngestConfig implements ExtractionContextProvider {
         return this.getInput().getId().getGenerator();
     }
 
-    /**
-     *
-     * @return
-     */
     @Override
     public IdConfig.ExistenceCheck existenceCheck() {
         return this.input.getId().getExistenceCheckMode();
@@ -328,19 +324,11 @@ public final class IngestConfig implements ExtractionContextProvider {
         return this.database.getSelectorSupplier();
     }
 
-    /**
-     *
-     * @return
-     */
     @Override
     public File outputLocation() {
         return this.pipeline.getOutputLocation();
     }
 
-    /**
-     *
-     * @return
-     */
     @Override
     public int threadPoolSize() {
         return this.pipeline.getThreadPoolSize();

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
@@ -32,7 +32,7 @@ public class InputConfig {
         this.path = path;
     }
 
-    @JsonProperty(required = true)
+    @JsonProperty()
     public String getRelTo() {
         return relTo;
     }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
@@ -13,8 +13,6 @@ public class InputConfig {
     private String name;
     private Integer depth = 1;
 
-    private Integer skip = 0;
-    private Integer limit = Integer.MAX_VALUE;
     private IdConfig id = new IdConfig();
 
     @JsonProperty
@@ -47,21 +45,5 @@ public class InputConfig {
     }
     public void setDepth(Integer depth) {
         this.depth = depth;
-    }
-
-    @JsonProperty
-    public Integer getSkip() {
-        return skip;
-    }
-    public void setSkip(Integer skip) {
-        this.skip = skip;
-    }
-
-    @JsonProperty
-    public Integer getLimit() {
-        return limit;
-    }
-    public void setLimit(Integer limit) {
-        this.limit = limit;
     }
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/InputConfig.java
@@ -11,6 +11,7 @@ import org.vitrivr.cineast.core.config.IdConfig;
 public class InputConfig {
     private String path;
     private String name;
+    private String relTo;
     private Integer depth = 1;
 
     private IdConfig id = new IdConfig();
@@ -29,6 +30,14 @@ public class InputConfig {
     }
     public void setPath(String path) {
         this.path = path;
+    }
+
+    @JsonProperty(required = true)
+    public String getRelTo() {
+        return relTo;
+    }
+    public void setRelTo(String relTo) {
+        this.relTo = relTo;
     }
 
     @JsonProperty

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionDispatcher.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionDispatcher.java
@@ -54,7 +54,7 @@ public class ExtractionDispatcher {
     this.context = context;
 
     if (this.fileHandlerThread == null) {
-      this.handler = new GenericExtractionItemHandler(this.pathProvider, this.context, this.context.sourceType());
+      this.handler = new GenericExtractionItemHandler(this.pathProvider, this.context, this.context.getType());
       this.fileHandlerThread = new Thread((GenericExtractionItemHandler) handler);
     } else {
       LOGGER.warn("You cannot initialize the current instance of ExtractionDispatcher again!");

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/path/ExtractionContainerProviderFactory.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/path/ExtractionContainerProviderFactory.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.standalone.run.path;
 
+import java.nio.file.Paths;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.extraction.ExtractionContextProvider;
@@ -29,15 +30,25 @@ public class ExtractionContainerProviderFactory {
     if (!context.inputPath().isPresent()) {
       return new NoContainerProvider();
     }
-    Path path = jobDirectory.resolve(context.inputPath().get()).normalize().toAbsolutePath();
+    Path inputPath = context.inputPath().get();
+    Path basePath;
+    Path startPath;
+    if (context.relPath().isPresent()) {
+      basePath = context.relPath().get();
+      startPath = inputPath;
+    } else {
+      basePath = inputPath;
+      startPath = Paths.get("");
+    }
+    basePath = jobDirectory.resolve(basePath).normalize().toAbsolutePath();
 
-    if (!Files.exists(path)) {
+    if (!Files.exists(basePath)) {
       LOGGER.warn("The path '{}' specified in the extraction configuration does not exist!",
-          path.toString());
+          basePath.toString());
       return new NoContainerProvider();
     }
 
-    return new TreeWalkContainerIteratorProvider(path, context);
+    return new TreeWalkContainerIteratorProvider(basePath, startPath, context.depth());
   }
 
 }


### PR DESCRIPTION
## Changes

- Implemented skipping of directory paths during extraction, since the directory files themselves are not processed by any extractors and only print unsupported file type debug messages
- Removed unused and deprecated fields in InputConfig
- Removed some empty Javadoc comments and minor cleanup