### PR TITLE
Automatically executing optimize after extraction if no flag is set

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionCompleteListener.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionCompleteListener.java
@@ -9,6 +9,14 @@ public interface ExtractionCompleteListener {
      * This method is called after the decoder for the object has been closed.
      * There might still be scheduled or ongoing {@link org.vitrivr.cineast.standalone.runtime.ExtractionTask}s for this object.
      */
-    void onCompleted(ExtractionItemContainer path);
+    default void onCompleted(ExtractionItemContainer path){
+        //ignore
+    }
 
+    /**
+     * This method is called when the extraction is completely finished. All resources are relinquished and no tasks are ongoing anymore.
+     */
+    default void extractionComplete(){
+        //ignore
+    }
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
@@ -328,6 +328,7 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
       });
       this.pathProvider.close();
       LOGGER.debug("Shutdown complete");
+      this.completeListeners.forEach(ExtractionCompleteListener::extractionComplete);
     }
   }
 


### PR DESCRIPTION
See discussion in #121. If cottontail is not used, the `OptimizeEntitiesCommand` simply returns without doing anything.