### PR TITLE
Fixed Cineast sometimes not shutting down completely.

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
@@ -92,6 +92,7 @@ public class APIEndpoint {
   private static final String CONTEXT = "api";
   public static ContinuousRetrievalLogic retrievalLogic = new ContinuousRetrievalLogic(Config.sharedConfig().getDatabase()); //TODO there is certainly a nicer way to do this...
   private static APIEndpoint instance = null;
+  private WebsocketAPI webSocketApi = null;
   private final List<DocumentedRestHandler> restHandlers = new ArrayList<>();
   /**
    * References to the HTTP and HTTPS service.
@@ -120,6 +121,7 @@ public class APIEndpoint {
     if (instance != null) {
       instance.shutdown();
     }
+    retrievalLogic.shutdown();
   }
   
   /**
@@ -160,6 +162,9 @@ public class APIEndpoint {
     if (Config.sharedConfig().getApi().getEnableRestSecure() || Config.sharedConfig().getApi()
         .getEnableWebsocketSecure()) {
       https.stop();
+    }
+    if (Config.sharedConfig().getApi().getEnableWebsocket()) {
+      webSocketApi.shutdown();
     }
   }
   
@@ -238,7 +243,7 @@ public class APIEndpoint {
     
     /* Enable WebSocket (if configured). */
     if (config.getEnableWebsocket()) {
-      WebsocketAPI webSocketApi = new WebsocketAPI();
+      this.webSocketApi = new WebsocketAPI();
       
       service.ws(String.format("%s/websocket", namespace()), handler -> {
         handler.onConnect(ctx -> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
@@ -57,6 +57,19 @@ public class WebsocketAPI {
 
     /* */
     private JacksonJsonProvider reader = new JacksonJsonProvider();
+
+    /**
+     * Shuts down this WebsocketAPIs ThreadPoolExecutor.
+     */
+    public void shutdown() {
+        EXECUTORS.shutdown();
+        try {
+            EXECUTORS.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        EXECUTORS.shutdownNow();
+    }
  
     /**
      * Invoked whenever a new connection is established. Configures the session and stashes it in the {@link WebsocketAPI#SESSIONS} map.
@@ -75,8 +88,6 @@ public class WebsocketAPI {
      * Invoked whenever a new connection is closed. Removes the session from the {@link WebsocketAPI#SESSIONS} map.
      *
      * @param session Session associated with the new connection.
-     * @param statusCode
-     * @param reason
      */
     @OnWebSocketClose
     public void closed(Session session, int statusCode, String reason) {
@@ -84,11 +95,8 @@ public class WebsocketAPI {
         LOGGER.debug("Connection of session closed (Code: {}, Reason: {}).", statusCode, reason);
     }
 
-    /**
+    /*
      * TODO: Handle errors properly.
-     *
-     * @param session
-     * @param error
      */
     @OnWebSocketError
     public void onWebSocketException(Session session, Throwable error) {

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/monitoring/PrometheusServer.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/monitoring/PrometheusServer.java
@@ -30,10 +30,12 @@ public class PrometheusServer {
     }
     if (initalized) {
       LOGGER.info("Prometheus already initalized");
+      lock.release();
       return;
     }
     if (!Config.sharedConfig().getMonitoring().enablePrometheus) {
       LOGGER.info("Prometheus monitoring not enabled");
+      lock.release();
       return;
     }
     DefaultExports.initialize();

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/runtime/ContinuousQueryDispatcher.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/runtime/ContinuousQueryDispatcher.java
@@ -126,6 +126,15 @@ public class ContinuousQueryDispatcher {
     taskQueue.clear();
     if (executor != null) {
       executor.shutdown();
+      try {
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      List<Runnable> runnables = executor.shutdownNow();
+      if(runnables.size()>0){
+        LOGGER.warn("{} threads terminated prematurely", runnables.size());
+      }
       executor = null;
     }
   }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/util/ContinuousRetrievalLogic.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/util/ContinuousRetrievalLogic.java
@@ -101,8 +101,8 @@ public class ContinuousRetrievalLogic {
     ContinuousQueryDispatcher.removeRetrievalResultListener(listener);
   }
 
-  // TODO: Is this method actually needed?
   public void shutdown() {
     ContinuousQueryDispatcher.shutdown();
+    segmentReader.close();
   }
 }


### PR DESCRIPTION
Problems identified and fixed include:
- WebSocket ThreadPoolExecutor not being closed at shutdown (would prevent correct shutdown after established WebSocket connection)
- ContinuousRetrievalLogic resources not properly closed
- ThreadPoolExecutor in ContinuousQueryDispatcher not guaranteed to be shut down