### PR TITLE
Extraction blocking

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -53,8 +53,8 @@ public class ExtractionCommand implements Runnable {
               }
             });
           }
-          dispatcher.start();
           dispatcher.registerListener((ExtractionCompleteListener) provider);
+          dispatcher.start();
           dispatcher.block();
         } else {
           System.err.printf("Could not start handleExtraction with configuration file '%s'. Does the file exist?%n", file.toString());

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -55,6 +55,7 @@ public class ExtractionCommand implements Runnable {
           }
           dispatcher.start();
           dispatcher.registerListener((ExtractionCompleteListener) provider);
+          dispatcher.block();
         } else {
           System.err.printf("Could not start handleExtraction with configuration file '%s'. Does the file exist?%n", file.toString());
         }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionDispatcher.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionDispatcher.java
@@ -78,6 +78,21 @@ public class ExtractionDispatcher {
     }
   }
 
+  /**
+   * Blocks until the extraction process thread is completed.
+   */
+  public synchronized void block() {
+    if (fileHandlerThread == null) {
+      LOGGER.warn("Tried to wait for extraction thread before extraction thread was initialized!");
+      return;
+    }
+    try {
+      fileHandlerThread.join();
+    } catch (InterruptedException e) {
+      LOGGER.error("Interrupted while waiting for extraction thread to complete!");
+    }
+  }
+
   public void registerListener(ExtractionCompleteListener listener) {
     if (this.fileHandlerThread == null) {
       LOGGER.error("Could not register listener, no thread available");

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionItemProcessor.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/ExtractionItemProcessor.java
@@ -7,6 +7,6 @@ package org.vitrivr.cineast.standalone.run;
  */
 public interface ExtractionItemProcessor {
 
-  public void addExtractionCompleteListener(ExtractionCompleteListener listener);
+  void addExtractionCompleteListener(ExtractionCompleteListener listener);
 
 }


### PR DESCRIPTION
Implemented blocking in the extraction command.

The extraction command was previously run independently on a separate thread, which allowed other commands to be run from the CLI in parallel, potentially causing problems. This commit introduces a blocking call so that the main thread responsible for the CLI waits to join the extraction thread.