### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM openjdk:14-buster AS build
+
+RUN apt-get update && \
+  apt-get install -y maven
+COPY . /cineast-src
+RUN cd /cineast-src && \
+  ./gradlew :cineast-core:generateProto && \
+  ./gradlew getExternalFiles && \
+  ./gradlew fatJar
+
+FROM openjdk:14-slim-buster
+
+RUN mkdir -p /opt/cineast
+
+COPY --from=build \
+  /cineast-src/cineast.json \
+  /opt/cineast/cineast.json
+
+COPY --from=build \
+  /cineast-src/cineast-runtime/build/libs/cineast-runtime-*-full.jar \
+  /opt/cineast/cineast-cli.jar
+
+COPY --from=build \
+  /cineast-src/cineast-api/build/libs/cineast-api-*-full.jar \
+  /opt/cineast/cineast-api.jar
+
+COPY --from=build \
+  /cineast-src/resources \
+  /opt/cineast/resources
+
+RUN printf '#!/bin/bash\n\
+if [ "$1" != "api" ] && [ "$1" != "cli" ]; then\n\
+    echo "Usage: $0 api|cli" >&2\n\
+    exit 1\n\
+fi\n\
+cd /opt/cineast/ && java -jar cineast-$1.jar ${@:2}'\
+> /opt/cineast/bootstrap.sh
+RUN chmod +x /opt/cineast/bootstrap.sh
+
+EXPOSE 4567
+EXPOSE 4568
+
+ENTRYPOINT ["/opt/cineast/bootstrap.sh"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ $> java -jar cineast-runtime/build/libs/cineast-runtime-x.x-full.jar cineast.jso
 
 For more setup information, consult our [Wiki](https://github.com/vitrivr/cineast/wiki)
 
+## Docker image
+
+There is a Docker image available [on Docker
+Hub](https://hub.docker.com/repository/docker/vitrivr/cineast).
+
+You can then run the CLI with:
+```
+$> docker run vitrivr/cineast cli cineast.json help
+```
+
+To change the configuration you can use a bind mount, e.g. to run the API
+server with custom configuration file cineast.json in the current directory:
+```
+$> docker run \
+  --mount type=bind,source="$(pwd)"/cineast.json,target=/opt/cineast/cineast.json \
+  cineast.json vitrivr/cineast api cineast.json
+```
+
 ## Generate OpenApi Specification
 
 If you need to rebuild the OpenApi Specification (OAS), there is a gradle task for this purpose:

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Docker hub does a recursive clone, then checks the branch out,
+# so when a PR adds a submodule (or updates it), it fails.
+git submodule update --init


### PR DESCRIPTION
I have been using my own Singularity recipe up until now but:

 1. Building Docker images on Docker Hub for use with Singularity seems to actually be a better option in many cases than using Singularity + SingularityHub (more info: https://github.com/frankier/gsoc2020/wiki/Should-you-avoid-using-Singularity-and-Singularity-Hub-to-build-your-Singularity-images%3F )
 2. Docker is commonplace so this is presumably more useful to others
 3. Docker Hub makes it easy for everyone to get autobuilds of their own branches/PRs

This exposes a custom entrypoint so we can choose to use either `docker run cineast api` or `docker run cineast cli` to run either the server+repl or the cli.

Ready to merge if the Docker Hub build works https://hub.docker.com/repository/registry-1.docker.io/frankierr/cineast/builds/5cf8cad5-0671-47ca-b2bd-6d3d96a55888

See also: https://github.com/vitrivr/cottontaildb/pull/44