### PR TITLE
Stop new CottontailEntityCreators flooding Cottontail new schema creations

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailEntityCreator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailEntityCreator.java
@@ -37,7 +37,7 @@ public class CottontailEntityCreator implements EntityCreator {
   }
 
   private void init() {
-    cottontail.createSchema("cineast");
+    cottontail.ensureSchemaBlocking("cineast");
   }
 
   @Override

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWrapper.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWrapper.java
@@ -19,6 +19,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -30,13 +32,13 @@ import org.vitrivr.cineast.core.util.LogHelper;
 public class CottontailWrapper implements AutoCloseable {
 
   private static final Logger LOGGER = LogManager.getLogger();
-
   private static final InsertStatus INTERRUPTED_INSERT = InsertStatus.newBuilder().setSuccess(false).build();
 
   private final ManagedChannel channel;
   private final CottonDDLFutureStub definitionFutureStub;
   private final CottonDMLStub managementStub;
   private final CottonDMLStub insertStub;
+  private final HashSet<String> ensuredSchemas = new HashSet<>();
 
   private static final int maxMessageSize = 10_000_000;
   private static final long MAX_QUERY_CALL_TIMEOUT = 300_000; //TODO expose to config
@@ -132,6 +134,25 @@ public class CottontailWrapper implements AutoCloseable {
       LOGGER.error("error in createSchemaBlocking: {}", LogHelper.getStackTrace(e));
       return false;
     }
+  }
+
+  public synchronized void ensureSchemaBlocking(String schema) {
+    if (this.ensuredSchemas.contains(schema)) {
+      return;
+    }
+    final CottonDDLBlockingStub stub = CottonDDLGrpc.newBlockingStub(this.channel);
+    Iterator<Schema> existingSchemas = stub.listSchemas(Empty.getDefaultInstance());
+    boolean schemaExists = false;
+    while (existingSchemas.hasNext()) {
+      Schema existingSchema = existingSchemas.next();
+      if (existingSchema.getName().equals(schema)) {
+        schemaExists = true;
+      }
+    }
+    if (!schemaExists) {
+      this.createSchemaBlocking(schema);
+    }
+    this.ensuredSchemas.add(schema);
   }
 
   public boolean insert(List<InsertMessage> messages) {


### PR DESCRIPTION
Otherwise I get a bunch of log messages like these:

```
2020-08-13 10:44:52 ERROR CottonDDLService:37 - Error while creating schema
org.vitrivr.cottontail.model.exceptions.DatabaseException$SchemaAlreadyExistsException: Schema 'warren.cineast' does already exist!
        at org.vitrivr.cottontail.database.catalogue.Catalogue.createSchema(Catalogue.kt:121)
        at org.vitrivr.cottontail.server.grpc.services.CottonDDLService.createSchema(CottonDDLService.kt:33)
        at org.vitrivr.cottontail.grpc.CottonDDLGrpc$MethodHandlers.invoke(CottonDDLGrpc.java:1055)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:172)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:820)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

This seems to be the culprit, although for some async/rpc type reason it doesn't show in the stack trace.