### PR TITLE
Make default cache location configurable

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/query/containers/ImageQueryContainer.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/query/containers/ImageQueryContainer.java
@@ -38,11 +38,11 @@ public class ImageQueryContainer extends QueryContainer {
 	}
 
 	public ImageQueryContainer(BufferedImage image) {
-		this(image, CachedDataFactory.DEFAULT_INSTANCE);
+		this(image, CachedDataFactory.getDefault());
 	}
 
 	public ImageQueryContainer(String data){
-		this(data, CachedDataFactory.DEFAULT_INSTANCE);
+		this(data, CachedDataFactory.getDefault());
 	}
 
 	public ImageQueryContainer(MultiImage img){

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/query/containers/ModelQueryContainer.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/query/containers/ModelQueryContainer.java
@@ -48,7 +48,7 @@ public class ModelQueryContainer extends QueryContainer {
     }
 
     public ModelQueryContainer(String data){
-        this(data, CachedDataFactory.DEFAULT_INSTANCE);
+        this(data, CachedDataFactory.getDefault());
     }
 
     /**

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/raw/CachedDataFactory.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/raw/CachedDataFactory.java
@@ -41,9 +41,16 @@ import java.util.Comparator;
  * @see CachedMultiImage
  */
 public class CachedDataFactory {
+    private static CachedDataFactory defaultInstance = new CachedDataFactory(new CacheConfig());
 
     /** Default instance of {@link CachedDataFactory}. */
-    public static final CachedDataFactory DEFAULT_INSTANCE = new CachedDataFactory(new CacheConfig());
+    public static CachedDataFactory getDefault() {
+      return defaultInstance;
+    }
+
+    public static void configureDefault(CacheConfig cacheConfig) {
+      defaultInstance = new CachedDataFactory(cacheConfig);
+    }
 
     /** A {@link ReentrantLock} to mediate access to CACHED_REFS. */
     private static final ReentrantLock CACHED_REFS_LOCK = new ReentrantLock();

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/Config.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/Config.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.config.*;
 import org.vitrivr.cineast.core.data.MediaType;
+import org.vitrivr.cineast.core.data.raw.CachedDataFactory;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 
 import java.io.File;
@@ -27,7 +28,6 @@ public class Config {
     private BenchmarkConfig benchmark = new BenchmarkConfig();
     private MonitoringConfig monitoring = new MonitoringConfig();
 
-
     /**
      * Accessor for shared (i.e. application wide) configuration.
      *
@@ -35,7 +35,7 @@ public class Config {
      */
     public synchronized static Config sharedConfig() {
         if (sharedConfig == null) {
-            sharedConfig = loadConfig("cineast.json");
+            loadConfig("cineast.json");
         }
         return sharedConfig;
     }
@@ -52,12 +52,20 @@ public class Config {
       return null;
     } else {
       LOGGER.info("Config file loaded!");
-      sharedConfig = config;
+      initSharedConfig(config);
       return config;
     }
   }
 
-    @JsonProperty
+  public static void initSharedConfig(Config config) {
+    sharedConfig = config;
+    if (config.cache != null) {
+      CachedDataFactory.configureDefault(config.cache);
+    }
+  }
+
+
+  @JsonProperty
     public APIConfig getApi() {
         return api;
     }


### PR DESCRIPTION
Use the cache key of whichever sharedConfig has been loaded last to
provide the configuration for the default CachedDataFactory instance

Closes #113 