### PR TITLE
Import command safety

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -23,7 +23,7 @@ import org.vitrivr.cineast.standalone.run.path.ExtractionContainerProviderFactor
 public class ExtractionCommand implements Runnable {
 
   @Option(name = {"-e", "--extraction"}, title = "Extraction config", description = "Path that points to a valid Cineast extraction config file.")
-  private String extractionConfig;
+  private String extractionConfig = null;
 
   @Option(name = {"--no-finalize"}, title = "Do Not Finalize", description = "If this flag is not set, automatically rebuilds indices & optimizes all entities when writing to cottontail after the extraction. Set this flag when you want more performance with external parallelism.")
   private boolean doNotFinalize = false;

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -5,6 +5,7 @@ import com.github.rvesse.airline.annotations.Option;
 import java.io.File;
 import java.io.IOException;
 
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.vitrivr.cineast.core.config.DatabaseConfig;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 import org.vitrivr.cineast.standalone.config.IngestConfig;
@@ -22,8 +23,9 @@ import org.vitrivr.cineast.standalone.run.path.ExtractionContainerProviderFactor
 @Command(name = "extract", description = "Starts a media extracting using the specified settings.")
 public class ExtractionCommand implements Runnable {
 
+  @Required
   @Option(name = {"-e", "--extraction"}, title = "Extraction config", description = "Path that points to a valid Cineast extraction config file.")
-  private String extractionConfig = null;
+  private String extractionConfig;
 
   @Option(name = {"--no-finalize"}, title = "Do Not Finalize", description = "If this flag is not set, automatically rebuilds indices & optimizes all entities when writing to cottontail after the extraction. Set this flag when you want more performance with external parallelism.")
   private boolean doNotFinalize = false;
@@ -32,11 +34,6 @@ public class ExtractionCommand implements Runnable {
   @Override
   public void run() {
     final ExtractionDispatcher dispatcher = new ExtractionDispatcher();
-    /* Prevent NullPointerException crash when extraction config isn't provided */
-    if (this.extractionConfig == null) {
-      System.err.println("No extraction config argument provided!");
-      return;
-    }
     final File file = new File(this.extractionConfig);
     if (file.exists()) {
       try {

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
@@ -32,10 +32,10 @@ import org.vitrivr.cineast.standalone.importer.vbs2019.v3c1analysis.FacesImportH
 public class ImportCommand implements Runnable {
 
   @Option(name = {"-t", "--type"}, description = "Type of data import that should be started.")
-  private String type;
+  private String type = null;
 
   @Option(name = {"-i", "--input"}, description = "The source file or folder for data import. If a folder is specified, the entire content will be considered for import.")
-  private String input;
+  private String input = null;
 
   @Option(name = {"--threads"}, description = "Level of parallelization for import")
   private int threads = 2;
@@ -51,6 +51,14 @@ public class ImportCommand implements Runnable {
 
   @Override
   public void run() {
+    if (type == null) {
+      System.err.println("No type argument provided!");
+      return;
+    }
+    if (input == null) {
+      System.err.println("No import argument provided!");
+      return;
+    }
     System.out.println(String.format("Starting import of type %s for '%s'.", this.type, this.input));
     final Path path = Paths.get(this.input);
     final ImportType type = ImportType.valueOf(this.type.toUpperCase());

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.vitrivr.cineast.core.config.DatabaseConfig;
 import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.importer.handlers.*;
@@ -31,11 +32,13 @@ import org.vitrivr.cineast.standalone.importer.vbs2019.v3c1analysis.FacesImportH
 @Command(name = "import", description = "Starts import of pre-extracted data.")
 public class ImportCommand implements Runnable {
 
+  @Required
   @Option(name = {"-t", "--type"}, description = "Type of data import that should be started.")
-  private String type = null;
+  private String type;
 
+  @Required
   @Option(name = {"-i", "--input"}, description = "The source file or folder for data import. If a folder is specified, the entire content will be considered for import.")
-  private String input = null;
+  private String input;
 
   @Option(name = {"--threads"}, description = "Level of parallelization for import")
   private int threads = 2;
@@ -51,14 +54,6 @@ public class ImportCommand implements Runnable {
 
   @Override
   public void run() {
-    if (type == null) {
-      System.err.println("No type argument provided!");
-      return;
-    }
-    if (input == null) {
-      System.err.println("No import argument provided!");
-      return;
-    }
     System.out.println(String.format("Starting import of type %s for '%s'.", this.type, this.input));
     final Path path = Paths.get(this.input);
     final ImportType type = ImportType.valueOf(this.type.toUpperCase());


### PR DESCRIPTION
Running import without type or input arguments would cause a NullPointerException and crash the CLI.

Fixed to only print a descriptive error message and return to the CLI.