### PR TITLE
Api documentation and checkstyle enforcment

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
@@ -62,13 +62,18 @@ import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
 
 /**
- * This class establishes a HTTP API endpoint listening on the specified port(s). The HTTP handling is facilitated by the Javalin framework (https://javalin.io/).
- * <p>
- * The {@link APIEndpoint} class supports setup for both the WebSocket and RestFul API endpoints, depending on the configuration.
- * <p>
- * Incoming requests are routed towards a {@link DocumentedRestHandler} based on the HTTP method and the URL, provided that such a handler hasn't been registered beforehand.
- * <p>
- * WebSocket communication is forwarded to the {@link WebsocketAPI} class, which handles incoming packets.
+ * This class establishes a HTTP API endpoint listening on the specified port(s). The HTTP handling
+ * is facilitated by the Javalin framework (https://javalin.io/).
+ *
+ * <p>The {@link APIEndpoint} class supports setup for both the WebSocket and RestFul API
+ * endpoints,
+ * depending on the configuration.</p>
+ * <p> Incoming requests are routed towards a {@link DocumentedRestHandler} based on the HTTP method
+ * and
+ * the URL, provided that such a handler hasn't been registered beforehand.</p>
+ * <p> WebSocket communication is forwarded to the {@link WebsocketAPI} class, which handles
+ * incoming
+ * packets.</p>
  *
  * @see WebsocketAPI
  */
@@ -80,7 +85,9 @@ public class APIEndpoint {
   public static final String VERSION = "v1";
 
   /**
-   * The Logger used by the api to log general things. It is recommended that {@link org.vitrivr.cineast.api.rest.handlers.interfaces.RestHandler}s provide own loggers for more logging control.
+   * The Logger used by the api to log general things. It is recommended that {@link
+   * org.vitrivr.cineast.api.rest.handlers.interfaces.RestHandler}s provide own loggers for more
+   * logging control.
    */
   private static final Logger LOGGER = LogManager.getLogger();
   /**
@@ -159,7 +166,8 @@ public class APIEndpoint {
    * Returns the non-secure {@link Javalin} instance this API uses
    *
    * <p>
-   * *   <b>Warning</b> This is only exposed for {@link OpenApiCompatHelper} and might be removed * in a future update * </p>
+   * *   <b>Warning</b> This is only exposed for {@link OpenApiCompatHelper} and might be removed *
+   * in a future update * </p>
    *
    * @return The non-secure http instance this API uses
    */
@@ -223,7 +231,8 @@ public class APIEndpoint {
   }
 
   /**
-   * Dispatches a new Jetty {@link Javalin} (HTTP endpoint). The method takes care of all the necessary setup.
+   * Dispatches a new Jetty {@link Javalin} (HTTP endpoint). The method takes care of all the
+   * necessary setup.
    *
    * @param secure If true, the new Service will be setup as secure with TLS enabled.
    * @return {@link Javalin}
@@ -356,7 +365,8 @@ public class APIEndpoint {
   }
 
   /**
-   * Registers a {@link DocumentedRestHandler} according its specialisation with the corresponding http method. Currently, there are four specialisations:
+   * Registers a {@link DocumentedRestHandler} according its specialisation with the corresponding
+   * http method. Currently, there are four specialisations:
    * <ul>
    *   <li>{@link GetRestHandler} for HTTP method <code>GET</code></li>
    *   <li>{@link PostRestHandler} for HTTP method <code>POST</code></li>
@@ -434,7 +444,8 @@ public class APIEndpoint {
   }
 
   /**
-   * If configured, this registers two special routes that serve the media objects as media content and additionally a thumbnails endpoint for them.
+   * If configured, this registers two special routes that serve the media objects as media content
+   * and additionally a thumbnails endpoint for them.
    *
    * @param service
    * @param config
@@ -454,7 +465,7 @@ public class APIEndpoint {
                 Config.sharedConfig().getDatabase().getSelectorSupplier().get()),
             ((baseDir, object) -> {
 //              String ext = object.getPath().substring(object.getPath().lastIndexOf('.'));
-              String ext = "."+Config.sharedConfig().getApi().getVideoExtension();
+              String ext = "." + Config.sharedConfig().getApi().getVideoExtension();
               return new File(baseDir, object.getObjectId() + ext);
             }));
       } else {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/GRPCEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/GRPCEndpoint.java
@@ -28,8 +28,10 @@ public class GRPCEndpoint {
 
     LOGGER.info("Starting GRPC Endpoint at port {}", port);
 
-    server = ServerBuilder.forPort(port).addService(new CineastQueryService(APIEndpoint.retrievalLogic)) //FIXME this should come from a more reasonable location
-        .addService(new CineastExtractionService()).addService(new CineastManagementService()).build();
+    server = ServerBuilder.forPort(port).addService(new CineastQueryService(
+        APIEndpoint.retrievalLogic)) //FIXME this should come from a more reasonable location
+        .addService(new CineastExtractionService()).addService(new CineastManagementService())
+        .build();
 
     try {
       server.start();

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
@@ -22,7 +22,8 @@ public class Main {
     /* (Force) load application config. */
     if (args.length != 0) {
       if (Config.loadConfig(args[0]) == null) {
-        System.err.println("Failed to load Cineast configuration from '" + args[0] + "'. Cineast API will shutdown...");
+        System.err.println("Failed to load Cineast configuration from '" + args[0]
+            + "'. Cineast API will shutdown...");
         System.exit(1);
       }
     }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/SessionExtractionContainer.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/SessionExtractionContainer.java
@@ -1,6 +1,9 @@
 package org.vitrivr.cineast.api;
 
 import io.prometheus.client.Counter;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
@@ -9,10 +12,6 @@ import org.vitrivr.cineast.standalone.config.IngestConfig;
 import org.vitrivr.cineast.standalone.run.ExtractionDispatcher;
 import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
 import org.vitrivr.cineast.standalone.run.path.SessionContainerProvider;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
 
 
 /**

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
@@ -1,38 +1,81 @@
 package org.vitrivr.cineast.api.messages.abstracts;
 
+import java.util.List;
 import org.vitrivr.cineast.api.messages.interfaces.QueryResultMessage;
 
-import java.util.List;
-
+/**
+ * A {@link AbstractQueryResultMessage} represents an abstract Query result to be implemented i.e. a
+ * result for a metadata lookup.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
+ */
 public abstract class AbstractQueryResultMessage<T> implements QueryResultMessage<T> {
 
+  /**
+   * The content of the query result message of type T.
+   */
   private List<T> content;
 
+  /**
+   * Class instance of type T to determine content type of the message.
+   */
   private final Class<T> contentType;
 
+  /**
+   * Query ID of the query to which this represents a result.
+   */
   private final String queryId;
 
+  /**
+   * Constructor for the AbstractQueryResultMessage object.
+   *
+   * @param queryId     The query ID of the query corresponding to this result.
+   * @param contentType Content type of the result.
+   * @param content     Result of the query.
+   */
   public AbstractQueryResultMessage(String queryId, Class<T> contentType, List<T> content) {
     this.queryId = queryId;
     this.contentType = contentType;
     this.content = content;
   }
 
+  /**
+   * Getter for queryId.
+   *
+   * @return String
+   */
   @Override
   public String getQueryId() {
     return this.queryId;
   }
 
+  /**
+   * Getter for content.
+   *
+   * @return List of type T
+   */
   @Override
   public List<T> getContent() {
     return this.content;
   }
 
+  /**
+   * Getter for content type.
+   *
+   * @return Class instance of type T.
+   */
   @Override
   public Class<T> getContentType() {
     return this.contentType;
   }
 
+  /**
+   * Get the size of the result content.
+   *
+   * @return int
+   */
   @Override
   public int count() {
     if (this.content != null) {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
@@ -8,7 +8,6 @@ import org.vitrivr.cineast.api.messages.interfaces.QueryResultMessage;
  * result for a metadata lookup.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public abstract class AbstractQueryResultMessage<T> implements QueryResultMessage<T> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
@@ -25,7 +25,6 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
  * keywords.</p>
  *
  * @author loris.sauter
- * @version 1.0
  * @created 04.08.18
  */
 @JsonTypeInfo(

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
@@ -1,27 +1,32 @@
 package org.vitrivr.cineast.api.messages.components;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 /**
  * Abstract descriptor of metadata filtering.
  *
- * This class serves as the superclass for metadata filters.
- *
- * Subclasses must implement {@link Predicate#test(Object)}, in which the filtering takes place.
- *
- * The ultimate goal is to list keywords, on which a list of {@link MediaObjectMetadataDescriptor}s is filtered.
- * Subclasses define on how to apply these keywords.
+ * <p>This class serves as the superclass for metadata filters.</p>
+ * <p>Subclasses must implement {@link Predicate#test(Object)}, in which the filtering takes
+ * place.</p>
+ * <p>The ultimate goal is to list keywords, on which a list of {@link
+ * MediaObjectMetadataDescriptor}s is filtered. Subclasses define on how to apply these
+ * keywords.</p>
  *
  * @author loris.sauter
+ * @version 1.0
+ * @created 04.08.18
  */
 @JsonTypeInfo(
     use = Id.NAME,
@@ -34,42 +39,83 @@ import java.util.stream.Collectors;
 public abstract class AbstractMetadataFilterDescriptor implements
     Predicate<MediaObjectMetadataDescriptor> {
 
+  /**
+   * Keywords name variable necessary for JSON creation.
+   */
   public static final String KEYWORDS_NAME = "keywords";
 
+  /**
+   * Keywords on which a list of {@link MediaObjectMetadataDescriptor}s is filtered.
+   */
   protected List<String> keywords;
 
+  /**
+   * This default constructor is required for deserialization by fasterxml/jackson.
+   */
   public AbstractMetadataFilterDescriptor() {
   }
 
+  /**
+   * Constructor for the AbstractMetadataFilterDescriptor object. Creates the internal list
+   * representation from the given array.
+   *
+   * @param keywords Array of keywords.
+   */
   public AbstractMetadataFilterDescriptor(String[] keywords) {
     this.keywords = Arrays.asList(keywords);
   }
 
+  /**
+   * Constructor for the AbstractMetadataFilterDescriptor object.
+   *
+   * @param keywords List of keywords.
+   */
   @JsonCreator
   public AbstractMetadataFilterDescriptor(@JsonProperty(KEYWORDS_NAME) List<String> keywords) {
     this.keywords = keywords;
   }
 
-  @JsonProperty(value = KEYWORDS_NAME)
-  public List<String> getKeywords() {
-    return keywords;
-  }
-
+  /**
+   * Setter for list of keywords.
+   */
   @JsonProperty(value = KEYWORDS_NAME)
   public void setKeywords(List<String> keywords) {
     this.keywords = keywords;
   }
 
+  /**
+   * Setter for array of keywords. Will be transformed into internal list representation.
+   */
+  @JsonIgnore
+  public void setKeywords(String[] keywords) {
+    this.keywords = Arrays.asList(keywords);
+  }
+
+  /**
+   * Getter for list of keywords.
+   *
+   * @return List of String
+   */
+  @JsonProperty(value = KEYWORDS_NAME)
+  public List<String> getKeywords() {
+    return keywords;
+  }
+
+  /**
+   * Getter for list of keywords as array.
+   *
+   * @return Array of String
+   */
   @JsonIgnore
   public String[] getKeywordsAsArray() {
     return keywords.toArray(new String[0]);
   }
 
-  @JsonIgnore
-  public void setKeywords(String[] keywords){
-    this.keywords = Arrays.asList(keywords);
-  }
-
+  /**
+   * Getter for list of keywords with keywords in lowercase.
+   *
+   * @return List of String
+   */
   @JsonIgnore
   public List<String> getKeywordsAsListLowercase() {
     return getKeywords().stream().map(String::toLowerCase).collect(Collectors.toList());

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
@@ -1,27 +1,39 @@
 package org.vitrivr.cineast.api.messages.components;
 
-import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
-
 import java.util.Arrays;
 import java.util.function.Predicate;
+import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 /**
  * Filter for metadata, based on the domain.
  *
- * This class servers as filter descriptor and as actual filter.
+ * <p> This class servers as filter descriptor and as actual filter.</p>
  *
  * @author loris.sauter
+ * @version 1.0
+ * @created 04.08.18
  */
 public class MetadataDomainFilter extends AbstractMetadataFilterDescriptor implements
     Predicate<MediaObjectMetadataDescriptor> {
 
-
+  /**
+   * Test filter to get a keywords list as lowercase to be applied on a {@link
+   * MediaObjectMetadataDescriptor}.
+   *
+   * @return boolean
+   */
   @Override
   public boolean test(MediaObjectMetadataDescriptor mediaObjectMetadataDescriptor) {
-    return getKeywordsAsListLowercase().contains(mediaObjectMetadataDescriptor.getDomain().toLowerCase());
+    return getKeywordsAsListLowercase()
+        .contains(mediaObjectMetadataDescriptor.getDomain().toLowerCase());
   }
 
-  public static MetadataDomainFilter createForKeywords(String...keywords){
+  /**
+   * Create a metadata domain filter instance for the given keywords.
+   *
+   * @return {@link MetadataDomainFilter}
+   */
+  public static MetadataDomainFilter createForKeywords(String... keywords) {
     MetadataDomainFilter filter = new MetadataDomainFilter();
     filter.setKeywords(keywords);
     return filter;
@@ -30,7 +42,7 @@ public class MetadataDomainFilter extends AbstractMetadataFilterDescriptor imple
   @Override
   public String toString() {
     return "MetadataDomainFilter{" +
-            "keywords=" + Arrays.toString(keywords.toArray()) +
-            '}';
+        "keywords=" + Arrays.toString(keywords.toArray()) +
+        '}';
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
@@ -10,7 +10,6 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
  * <p> This class servers as filter descriptor and as actual filter.</p>
  *
  * @author loris.sauter
- * @version 1.0
  * @created 04.08.18
  */
 public class MetadataDomainFilter extends AbstractMetadataFilterDescriptor implements

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
@@ -1,27 +1,39 @@
 package org.vitrivr.cineast.api.messages.components;
 
-import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
-
 import java.util.Arrays;
 import java.util.function.Predicate;
+import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 /**
  * Filter for metadata, based on the key.
  *
- * This class servers as filter descriptor and as actual filter.
+ * <p>This class servers as filter descriptor and as actual filter.</p>
  *
  * @author loris.sauter
+ * @version 1.0
+ * @created 04.08.18
  */
 public class MetadataKeyFilter extends AbstractMetadataFilterDescriptor implements
     Predicate<MediaObjectMetadataDescriptor> {
 
+  /**
+   * Test filter to get a keywords list as lowercase to be applied on a {@link
+   * MediaObjectMetadataDescriptor}.
+   *
+   * @return boolean
+   */
   @Override
   public boolean test(MediaObjectMetadataDescriptor mediaObjectMetadataDescriptor) {
     return getKeywordsAsListLowercase()
         .contains(mediaObjectMetadataDescriptor.getKey().toLowerCase());
   }
 
-  public static MetadataKeyFilter createForKeywords(String...keywords){
+  /**
+   * Create a metadata key filter instance for the given keywords.
+   *
+   * @return {@link MetadataDomainFilter}
+   */
+  public static MetadataKeyFilter createForKeywords(String... keywords) {
     MetadataKeyFilter filter = new MetadataKeyFilter();
     filter.setKeywords(keywords);
     return filter;
@@ -30,7 +42,7 @@ public class MetadataKeyFilter extends AbstractMetadataFilterDescriptor implemen
   @Override
   public String toString() {
     return "MetadataKeyFilter{" +
-            "keywords=" + Arrays.toString(keywords.toArray()) +
-            '}';
+        "keywords=" + Arrays.toString(keywords.toArray()) +
+        '}';
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
@@ -10,7 +10,6 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
  * <p>This class servers as filter descriptor and as actual filter.</p>
  *
  * @author loris.sauter
- * @version 1.0
  * @created 04.08.18
  */
 public class MetadataKeyFilter extends AbstractMetadataFilterDescriptor implements

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
@@ -3,21 +3,51 @@ package org.vitrivr.cineast.api.messages.credentials;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Credentials of an API session.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 08.05.17
+ */
 public class Credentials {
 
-private String username, password; //more options to come
-  
+  /**
+   * Username and password of an user in a session.
+   *
+   * <p> More options to come</p>
+   */
+  private String username;
+  private String password;
+
+  /**
+   * Constructor for the Credentials object.
+   *
+   * @param username Username of the user credentials.
+   * @param password Password of the user credentials.
+   */
   @JsonCreator
-  public Credentials(@JsonProperty("username") String username, @JsonProperty("password") String password){
+  public Credentials(@JsonProperty("username") String username,
+      @JsonProperty("password") String password) {
     this.username = username;
     this.password = password;
   }
-  
-  public String getUsername(){
+
+  /**
+   * Getter for username.
+   *
+   * @return String
+   */
+  public String getUsername() {
     return this.username;
   }
-  
-  public String getPassword(){
+
+  /**
+   * Getter for password.
+   *
+   * @return String
+   */
+  public String getPassword() {
     return this.password;
   }
 
@@ -25,5 +55,5 @@ private String username, password; //more options to come
   public String toString() {
     return String.format("Credentials [username=%s, password=%s]", username, password);
   }
-  
+
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Credentials of an API session.
  *
  * @author lucaro
- * @version 1.0
  * @created 08.05.17
  */
 public class Credentials {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
@@ -8,7 +8,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message type for a non-particular message that implements the message interface.
  *
  * @author rgasser
- * @version 1.0
  * @created 19.01.17
  */
 public class AnyMessage implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
@@ -5,26 +5,39 @@ import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
 /**
+ * Message type for a non-particular message that implements the message interface.
+ *
  * @author rgasser
  * @version 1.0
  * @created 19.01.17
  */
 public class AnyMessage implements Message {
-    private MessageType messageType;
 
-    @Override
-    @JsonProperty
-    public MessageType getMessageType() {
-        return this.messageType;
-    }
-    public void setMessagetype(MessageType messageType) {
-        this.messageType = messageType;
-    }
+  /**
+   * {@link MessageType} of the message.
+   */
+  private MessageType messageType;
 
-    @Override
-    public String toString() {
-        return "AnyMessage{" +
-                "messageType=" + messageType +
-                '}';
-    }
+  /**
+   * Setter for message type.
+   */
+  public void setMessagetype(MessageType messageType) {
+    this.messageType = messageType;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @JsonProperty
+  public MessageType getMessageType() {
+    return this.messageType;
+  }
+
+  @Override
+  public String toString() {
+    return "AnyMessage{" +
+        "messageType=" + messageType +
+        '}';
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
@@ -6,52 +6,82 @@ import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
 /**
+ * Message object for an error message.
+ *
  * @author rgasser
  * @version 1.0
  * @created 19.01.17
  */
 public class Error implements Message {
 
-    private String message;
-    private long timestamp;
+  /**
+   * Message content of the error.
+   */
+  private String message;
 
-    @JsonCreator
-    public Error(String message) {
-        this.message = message;
-        this.timestamp = System.currentTimeMillis();
-    }
+  /**
+   * Timestamp when the error was recorded.
+   */
+  private long timestamp;
 
-    @JsonProperty
-    public String getMessage() {
-        return message;
-    }
-    public void setMessage(String message) {
-        this.message = message;
-    }
+  /**
+   * Constructor for the Error object. Saves the timestamp of the creation of this error message.
+   *
+   * @param message Error message.
+   */
+  @JsonCreator
+  public Error(String message) {
+    this.message = message;
+    this.timestamp = System.currentTimeMillis();
+  }
 
-    @JsonProperty
-    public long getTimestamp() {
-        return timestamp;
-    }
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
+  /**
+   * Setter for timestamp.
+   */
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
 
-    /**
-     * Returns the type of particular message. Expressed as MessageTypes enum.
-     *
-     * @return
-     */
-    @Override
-    public MessageType getMessageType() {
-        return null;
-    }
+  /**
+   * Setter for message.
+   */
+  public void setMessage(String message) {
+    this.message = message;
+  }
 
-    @Override
-    public String toString() {
-        return "Error{" +
-                "message='" + message + '\'' +
-                ", timestamp=" + timestamp +
-                '}';
-    }
+  /**
+   * Getter for message.
+   *
+   * @return String
+   */
+  @JsonProperty
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Getter for timestamp.
+   *
+   * @return long
+   */
+  @JsonProperty
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "Error{" +
+        "message='" + message + '\'' +
+        ", timestamp=" + timestamp +
+        '}';
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
@@ -9,7 +9,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message object for an error message.
  *
  * @author rgasser
- * @version 1.0
  * @created 19.01.17
  */
 public class Error implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
@@ -5,40 +5,56 @@ import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
 /**
+ * Message object for an ping message.
+ *
  * @author rgasser
  * @version 1.0
  * @created 19.01.17
  */
 public class Ping implements Message {
-    public enum StatusEnum {
-        UNKNOWN,OK,ERROR
-    }
 
-    /** */
-    private StatusEnum status = StatusEnum.UNKNOWN;
+  /**
+   * Enum of the Ping status.
+   */
+  public enum StatusEnum {
+    UNKNOWN, OK, ERROR
+  }
 
-    @JsonProperty
-    public StatusEnum getStatus() {
-        return status;
-    }
-    public void setStatus(StatusEnum status) {
-        this.status = status;
-    }
+  /**
+   * Status of the Ping.
+   */
+  private StatusEnum status = StatusEnum.UNKNOWN;
 
-    /**
-     * Returns the type of particular message. Expressed as MessageTypes enum.
-     *
-     * @return
-     */
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.PING;
-    }
+  /**
+   * Setter for status.
+   */
+  public void setStatus(StatusEnum status) {
+    this.status = status;
+  }
 
-    @Override
-    public String toString() {
-        return "Ping{" +
-                "status=" + status +
-                '}';
-    }
+  /**
+   * Getter for status.
+   *
+   * @return {@link StatusEnum}
+   */
+  @JsonProperty
+  public StatusEnum getStatus() {
+    return status;
+  }
+
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.PING;
+  }
+
+  @Override
+  public String toString() {
+    return "Ping{" +
+        "status=" + status +
+        '}';
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
@@ -8,7 +8,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message object for an ping message.
  *
  * @author rgasser
- * @version 1.0
  * @created 19.01.17
  */
 public class Ping implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/Message.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/Message.java
@@ -4,7 +4,6 @@ package org.vitrivr.cineast.api.messages.interfaces;
  * Basic interface of every Message, which can be identified by its MessageType field.
  *
  * @author rgasser
- * @version 1.0
  * @created 12.01.17
  */
 public interface Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/Message.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/Message.java
@@ -1,7 +1,6 @@
 package org.vitrivr.cineast.api.messages.interfaces;
 
 /**
- *
  * Basic interface of every Message, which can be identified by its MessageType field.
  *
  * @author rgasser
@@ -9,10 +8,11 @@ package org.vitrivr.cineast.api.messages.interfaces;
  * @created 12.01.17
  */
 public interface Message {
-    /**
-     * Returns the type of particular message. Expressed as MessageTypes enum.
-     *
-     * @return
-     */
-    public MessageType getMessageType();
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  public MessageType getMessageType();
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/MessageType.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/MessageType.java
@@ -20,7 +20,6 @@ import org.vitrivr.cineast.api.messages.session.StartSessionMessage;
  * Defines the different MessageTypes used by the WebSocket and JSON API.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public enum MessageType {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/MessageType.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/MessageType.java
@@ -18,6 +18,10 @@ import org.vitrivr.cineast.api.messages.session.StartSessionMessage;
 
 /**
  * Defines the different MessageTypes used by the WebSocket and JSON API.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
  */
 public enum MessageType {
   /* Messages related to status updates. */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/QueryResultMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/QueryResultMessage.java
@@ -6,7 +6,6 @@ import java.util.List;
  * Defines the abstracts structure of a QueryResultMessage.
  *
  * @author rgasser
- * @version 1.0
  * @created 11.01.17
  */
 public interface QueryResultMessage<T> extends Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/QueryResultMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/interfaces/QueryResultMessage.java
@@ -10,31 +10,32 @@ import java.util.List;
  * @created 11.01.17
  */
 public interface QueryResultMessage<T> extends Message {
-    /**
-     * Returns the unique QueryId to which this QueryResultMessage belongs.
-     *
-     * @return QueryId (unique)
-     */
-    public String getQueryId();
 
-    /**
-     * Returns a list of the content this QueryResultMessage contains. Has type
-     *
-     * @return
-     */
-    public List<T> getContent();
+  /**
+   * Returns the unique QueryId to which this QueryResultMessage belongs.
+   *
+   * @return QueryId (unique)
+   */
+  public String getQueryId();
 
-    /**
-     * Returns the type of the query result content
-     * 
-     * @return
-     */
-    public Class<T> getContentType();
-    
-    /**
-     * Returns the number of items in the QueryResultMessage.
-     *
-     * @return Number of item in List<T>, returned by getContent()
-     */
-    int count();
+  /**
+   * Returns a list of the content this QueryResultMessage contains.
+   *
+   * @return List of type T
+   */
+  public List<T> getContent();
+
+  /**
+   * Returns the type of the query result content.
+   *
+   * @return Class of type T
+   */
+  public Class<T> getContentType();
+
+  /**
+   * Returns the number of items in the QueryResultMessage.
+   *
+   * @return Number of item in List<T>, returned by getContent()
+   */
+  int count();
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message from the requester to transfer table and column information of a request.
  *
  * @author silvanheller
- * @version 1.0
  * @created 22.07.20
  */
 public class ColumnSpecification implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
@@ -2,31 +2,67 @@ package org.vitrivr.cineast.api.messages.lookup;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.vitrivr.cineast.api.messages.credentials.Credentials;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * Message from the requester to transfer table and column information of a request.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 22.07.20
+ */
 public class ColumnSpecification implements Message {
 
+  /**
+   * The requested table.
+   */
   private String table;
+
+  /**
+   * The requested column.
+   */
   private String column;
 
-  public String getTable() {
-    return table;
-  }
-
-  public String getColumn() {
-    return column;
-  }
-
+  /**
+   * Constructor for the ColumnSpecification object.
+   *
+   * @param column requested column.
+   * @param table  requested table.
+   */
   @JsonCreator
-  public ColumnSpecification(@JsonProperty("column") String column, @JsonProperty("table") String table) {
+  public ColumnSpecification(@JsonProperty("column") String column,
+      @JsonProperty("table") String table) {
     this.column = column;
     this.table = table;
   }
 
+  /**
+   * Getter for table.
+   *
+   * @return {@link Credentials}
+   */
+  public String getTable() {
+    return table;
+  }
+
+  /**
+   * Getter for column.
+   *
+   * @return {@link Credentials}
+   */
+  public String getColumn() {
+    return column;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return null;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
@@ -11,7 +11,6 @@ import java.util.List;
  * Object to store a list of string IDs.
  *
  * @author lucaro
- * @version 1.0
  * @created 10.05.17
  */
 public class IdList {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
@@ -3,31 +3,59 @@ package org.vitrivr.cineast.api.messages.lookup;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.vitrivr.cineast.api.messages.interfaces.Message;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class IdList{
+/**
+ * Object to store a list of string IDs.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 10.05.17
+ */
+public class IdList {
 
+  /**
+   * List of String IDs to be stored by this object.
+   */
   private List<String> ids;
 
+  /**
+   * Constructor for the IdList object. Creates the internal list representation from the given
+   * array.
+   *
+   * @param ids Array of IDs.
+   */
   public IdList(String[] ids) {
     this.ids = Arrays.asList(ids);
   }
 
+  /**
+   * Constructor for the IdList object. Creates a new list instance from the given list.
+   *
+   * @param ids List of IDs.
+   */
   @JsonCreator
   public IdList(@JsonProperty("ids") List<String> ids) {
     this.ids = new ArrayList<>(ids);
   }
 
+  /**
+   * Getter for array of IDs.
+   *
+   * @return Array of String
+   */
   public String[] getIds() {
     return this.ids.toArray(new String[0]);
   }
 
-  @JsonIgnore //prevents IDs being included in json a second time as "idList"
+  /**
+   * Getter for list of IDs.
+   *
+   * @return List of String
+   */
+  @JsonIgnore
   public List<String> getIdList() {
     return this.ids;
   }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message of a metadata lookup query by a requester.
  *
  * @author rgasser
- * @version 1.0
  * @created 10.02.17
  */
 public class MetadataLookup implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
@@ -2,60 +2,85 @@ package org.vitrivr.cineast.api.messages.lookup;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.vitrivr.cineast.api.messages.interfaces.Message;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.vitrivr.cineast.api.messages.interfaces.Message;
+import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
 /**
+ * Message of a metadata lookup query by a requester.
+ *
  * @author rgasser
  * @version 1.0
  * @created 10.02.17
  */
 public class MetadataLookup implements Message {
-    /** List of object ID's for which metadata should be looked up. */
-    private String[] objectIds;
 
-    /** List of metadata domains that should be considered. If empty, all domains are considered! */
-    private String[] domains;
+  /**
+   * Array of object ID's for which metadata should be looked up.
+   */
+  private String[] objectIds;
 
-    @JsonCreator
-    public MetadataLookup(@JsonProperty("objectids") String[] ids, @JsonProperty("domains") String[] domains) {
-        this.objectIds = ids;
-        this.domains = domains;
+  /**
+   * Array of metadata domains that should be considered. If empty, all domains are considered!
+   */
+  private String[] domains;
+
+  /**
+   * Constructor for the MetadataLookup object.
+   *
+   * @param ids     Array of String object IDs to be looked up.
+   * @param domains Array of String of the metadata domains to be considered.
+   */
+  @JsonCreator
+  public MetadataLookup(@JsonProperty("objectids") String[] ids,
+      @JsonProperty("domains") String[] domains) {
+    this.objectIds = ids;
+    this.domains = domains;
+  }
+
+  /**
+   * Getter for List of object IDs.
+   *
+   * @return List of String
+   */
+  public List<String> getIds() {
+    if (this.objectIds != null) {
+      return Arrays.asList(this.objectIds);
+    } else {
+      return new ArrayList<>(0);
     }
+  }
 
-    public List<String> getIds() {
-        if (this.objectIds != null) {
-            return Arrays.asList(this.objectIds);
-        } else {
-            return new ArrayList<>(0);
-        }
+  /**
+   * Getter for List of domains.
+   *
+   * @return List of String
+   */
+  public List<String> getDomains() {
+    if (this.domains != null) {
+      return Arrays.asList(this.domains);
+    } else {
+      return new ArrayList<>(0);
     }
+  }
 
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.M_LOOKUP;
+  }
 
-    public  List<String> getDomains() {
-        if (this.domains != null) {
-            return Arrays.asList(this.domains);
-        } else {
-            return new ArrayList<>(0);
-        }
-    }
-
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.M_LOOKUP;
-    }
-
-    @Override
-    public String toString() {
-        return "MetadataLookup{" +
-                "objectIds=" + Arrays.toString(objectIds) +
-                ", domains=" + Arrays.toString(domains) +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "MetadataLookup{" +
+        "objectIds=" + Arrays.toString(objectIds) +
+        ", domains=" + Arrays.toString(domains) +
+        '}';
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
@@ -16,7 +16,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * still realise that there are unknown properties</p>
  *
  * @author loris.sauter
- * @version 1.0
  * @created 04.08.18
  */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
@@ -2,30 +2,34 @@ package org.vitrivr.cineast.api.messages.lookup;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Arrays;
+import java.util.List;
 import org.vitrivr.cineast.api.messages.components.AbstractMetadataFilterDescriptor;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
- * Ignores unkown json properties, e.g. may contain no filter at all.
+ * Message of an optionally filtered list of IDs and filters to be applied on the metadata lookup.
+ *
+ * <p>ignoreUnknown = true ignores unknown json properties, e.g. may contain no filter at all.</p>
+ * <p>https://layer4.fr/blog/2013/08/19/how-to-map-unknown-json-properties-with-jackson/ how to
+ * still realise that there are unknown properties</p>
  *
  * @author loris.sauter
+ * @version 1.0
+ * @created 04.08.18
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OptionallyFilteredIdList implements Message {
 
-  /*
-  https://layer4.fr/blog/2013/08/19/how-to-map-unknown-json-properties-with-jackson/
-  how to still realise that there are unkown properties
+  /**
+   * List of {@link AbstractMetadataFilterDescriptor} to be applied on the metadata lookup.
    */
-
   private List<AbstractMetadataFilterDescriptor> filters;
 
+  /**
+   * List of IDs for which the metadata lookup should be performed.
+   */
   private List<String> ids;
 
   /**
@@ -34,41 +38,79 @@ public class OptionallyFilteredIdList implements Message {
   public OptionallyFilteredIdList() {
   }
 
-  public String[] getIds(){
-    return this.ids.toArray(new String[0]);
-  }
-
-  public List<String> getIdList(){ return this.ids;}
-
-  @Override
-  public MessageType getMessageType() {
-    return null;
-  }
-
-  public List<AbstractMetadataFilterDescriptor> getFilters() {
-    return filters;
-  }
-
-  @JsonIgnore
-  public boolean hasFilters(){
-    return filters != null;
-  }
-
+  /**
+   * Setter for the filters.
+   */
   public void setFilters(
       AbstractMetadataFilterDescriptor[] filters) {
     this.filters = Arrays.asList(filters);
   }
 
-  @JsonIgnore //prevents filters being included in json a second time as "filterList"
-  public List<AbstractMetadataFilterDescriptor> getFilterList(){
+  /**
+   * Getter for Array of lists.
+   *
+   * @return Array of String
+   */
+  public String[] getIds() {
+    return this.ids.toArray(new String[0]);
+  }
+
+  /**
+   * Getter for List of IDs.
+   *
+   * @return List of String
+   */
+  public List<String> getIdList() {
+    return this.ids;
+  }
+
+  /**
+   * Getter for List of {@link AbstractMetadataFilterDescriptor}.
+   *
+   * @return List of {@link AbstractMetadataFilterDescriptor}
+   */
+  public List<AbstractMetadataFilterDescriptor> getFilters() {
+    return filters;
+  }
+
+  /**
+   * Check if the optionally filtered list contains filters.
+   *
+   * <p>JsonIgnore prevents filters being included in json a second time as "filterList".</p>
+   *
+   * @return boolean
+   */
+  @JsonIgnore
+  public boolean hasFilters() {
+    return filters != null;
+  }
+
+  /**
+   * Check if the optionally filtered list contains filters.
+   *
+   * @return boolean
+   */
+  @JsonIgnore //
+  public List<AbstractMetadataFilterDescriptor> getFilterList() {
     return this.filters;
   }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return null;
+  }
+
 
   @Override
   public String toString() {
     return "OptionallyFilteredIdList{" +
-            "filters=" + Arrays.toString(filters.toArray()) +
-            ", ids=" + Arrays.toString(ids.toArray()) +
-            '}';
+        "filters=" + Arrays.toString(filters.toArray()) +
+        ", ids=" + Arrays.toString(ids.toArray()) +
+        '}';
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
@@ -2,69 +2,75 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.config.ReadableQueryConfig;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-
-import java.util.List;
 
 /**
- * This object represents a MoreLikeThisQuery message, i.e. a request for a similarity-search.
+ * This object represents a MoreLikeThisQuery message, i.e. a request for more items similar to a
+ * given item.
  *
  * @author rgasser
  * @version 1.0
  * @created 27.04.17
  */
 public class MoreLikeThisQuery extends Query {
-    /** ID of the segment that serves as example for the MLT query. */
-    private String segmentId;
 
-    /** List of feature categories that should be considered by the MLT query. */
-    private List<String> categories;
+  /**
+   * ID of the segment that serves as example for the more like this query.
+   */
+  private String segmentId;
 
-    /**
-     * Constructor for the SimilarityQuery object.
-     *
-     * @param segmentId SegmentId.
-     * @param categories List of named feature categories that should be considered when doing More-Like-This.
-     * @param config  The {@link ReadableQueryConfig}. May be null!
-     */
-    @JsonCreator
-    public MoreLikeThisQuery(@JsonProperty(value = "segmentId", required = true) String segmentId,
-                             @JsonProperty(value = "categories", required = true) List<String> categories,
-                             @JsonProperty(value = "config", required = false) QueryConfig config) {
-        super(config);
-        this.segmentId = segmentId;
-        this.categories = categories;
-    }
+  /**
+   * List of feature categories that should be considered by the MLT query.
+   */
+  private List<String> categories;
 
-    /**
-     * Getter for segmentId.
-     *
-     * @return
-     */
-    public String getSegmentId() {
-        return segmentId;
-    }
+  /**
+   * Constructor for the SimilarityQuery object.
+   *
+   * @param segmentId  SegmentId.
+   * @param categories List of named feature categories that should be considered when doing
+   *                   More-Like-This.
+   * @param config     The {@link ReadableQueryConfig}. May be null!
+   */
+  @JsonCreator
+  public MoreLikeThisQuery(@JsonProperty(value = "segmentId", required = true) String segmentId,
+      @JsonProperty(value = "categories", required = true) List<String> categories,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
+    super(config);
+    this.segmentId = segmentId;
+    this.categories = categories;
+  }
 
-    /**
-     * Getter for categories.
-     *
-     * @return
-     */
-    public List<String> getCategories() {
-        return this.categories;
-    }
+  /**
+   * Getter for segmentId.
+   *
+   * @return String
+   */
+  public String getSegmentId() {
+    return segmentId;
+  }
 
-    /**
-     * Returns the type of particular message. Expressed as MessageTypes enum.
-     *
-     * @return
-     */
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.Q_MLT;
-    }
+  /**
+   * Getter for categories.
+   *
+   * @return @return List of Strings
+   */
+  public List<String> getCategories() {
+    return this.categories;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.Q_MLT;
+  }
 
 }
 

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
@@ -63,9 +63,7 @@ public class MoreLikeThisQuery extends Query {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/MoreLikeThisQuery.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.config.ReadableQueryConfig;
  * given item.
  *
  * @author rgasser
- * @version 1.0
  * @created 27.04.17
  */
 public class MoreLikeThisQuery extends Query {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
@@ -61,9 +61,7 @@ public class NeighboringSegmentQuery extends Query {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
@@ -2,39 +2,72 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * A {@link NeighboringSegmentQuery} represents a query for neighbors of a given segment ID.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 04.01.18
+ */
 public class NeighboringSegmentQuery extends Query {
 
-    /** ID of the {@link MediaSegmentDescriptor} for which neighbors should be retrieved. */
-    private final String segmentId;
+  /**
+   * ID of the {@link MediaSegmentDescriptor} for which neighbors should be retrieved.
+   */
+  private final String segmentId;
 
-    /** Number of neighbors that should be retrieved. */
-    private final int count;
+  /**
+   * Number of neighbors that should be retrieved.
+   */
+  private final int count;
 
-    /** */
-    @JsonCreator
-    public NeighboringSegmentQuery(@JsonProperty(value = "segmentId", required = true) String segmentId,
-                                   @JsonProperty(value = "count", required = false) Integer count,
-                                   @JsonProperty(value = "config", required = false) QueryConfig config) {
-        super(config);
-        this.segmentId = segmentId;
-        this.count = count == null ? 3 : count;
-    }
+  /**
+   * Constructor for the NeighboringSegmentQuery object.
+   *
+   * @param segmentId ID of the {@link MediaSegmentDescriptor}.
+   * @param count     Number of neighbors to be retrieved.
+   * @param config    The {@link QueryConfig}. May be null!
+   */
+  @JsonCreator
+  public NeighboringSegmentQuery(
+      @JsonProperty(value = "segmentId", required = true) String segmentId,
+      @JsonProperty(value = "count", required = false) Integer count,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
+    super(config);
+    this.segmentId = segmentId;
+    this.count = count == null ? 3 : count;
+  }
 
-    public String getSegmentId() {
-        return segmentId;
-    }
+  /**
+   * Getter for the segment ID.
+   *
+   * @return String
+   */
+  public String getSegmentId() {
+    return segmentId;
+  }
 
-    public int getCount() {
-        return count;
-    }
+  /**
+   * Getter for the number of items to be retrieved.
+   *
+   * @return int
+   */
+  public int getCount() {
+    return count;
+  }
 
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.Q_NESEG;
-    }
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.Q_NESEG;
+  }
 
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/NeighboringSegmentQuery.java
@@ -10,7 +10,6 @@ import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
  * A {@link NeighboringSegmentQuery} represents a query for neighbors of a given segment ID.
  *
  * @author rgasser
- * @version 1.0
  * @created 04.01.18
  */
 public class NeighboringSegmentQuery extends Query {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
@@ -33,8 +33,9 @@ public abstract class Query implements Message {
   }
 
   /**
-   * JSON: the config field is specified in subclasses The JsonIgnore is needed because the actual
-   * field is not called queryconfig
+   * JSON: the config field is specified in subclasses.
+   *
+   * <p>The JsonIgnore is needed because the actual field is not called queryconfig</p>
    */
   @JsonIgnore
   public final QueryConfig getQueryConfig() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
@@ -13,7 +13,6 @@ import org.vitrivr.cineast.core.config.ReadableQueryConfig;
  * similarity-search.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public abstract class Query implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
@@ -1,34 +1,48 @@
 package org.vitrivr.cineast.api.messages.query;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.config.ReadableQueryConfig;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import org.vitrivr.cineast.api.messages.interfaces.Message;
-
+/**
+ * A {@link Query} represents an abstract Query to be implemented i.e. a request for a
+ * similarity-search.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
+ */
 public abstract class Query implements Message {
-    /** The {@link ReadableQueryConfig} that should be used to configure the query. May be null! */
-    protected final QueryConfig config;
 
-    public Query(QueryConfig config) {
-        this.config = config;
-    }
+  /**
+   * The {@link QueryConfig} that should be used to configure the query. May be null!
+   */
+  protected final QueryConfig config;
 
-    /**
-     * JSON: the config field is specified in subclasses
-     * The JsonIgnore is needed because the actual field is not called queryconfig
-     */
-    @JsonIgnore
-    public final QueryConfig getQueryConfig() {
-        return this.config;
-    }
+  /**
+   * Constructor for the Query object.
+   *
+   * @param config The {@link ReadableQueryConfig}. May be null!
+   */
+  public Query(QueryConfig config) {
+    this.config = config;
+  }
 
-    @Override
-    public String toString(){
-        return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
-    }
+  /**
+   * JSON: the config field is specified in subclasses The JsonIgnore is needed because the actual
+   * field is not called queryconfig
+   */
+  @JsonIgnore
+  public final QueryConfig getQueryConfig() {
+    return this.config;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryComponent.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryComponent.java
@@ -11,9 +11,11 @@ import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.data.query.containers.QueryContainer;
 
 /**
- * The wording is suboptimal. A {@link QueryComponent} has only one containerID, but multiple {@link QueryContainer}s are created out of it.
- *
+ * The wording is suboptimal. A {@link QueryComponent} has only one containerID, but multiple {@link
+ * QueryContainer}s are created out of it.
+ * <p>
  * These all have the {@link QueryComponent#containerId} of their parent.
+ *
  * @deprecated use {@link TemporalQuery} instead
  */
 @Deprecated
@@ -35,7 +37,8 @@ public class QueryComponent {
    * Constructor for QueryComponent.
    */
   @JsonCreator
-  public QueryComponent(@JsonProperty("terms") List<QueryTerm> terms, @JsonProperty("containerId") int containerId) {
+  public QueryComponent(@JsonProperty("terms") List<QueryTerm> terms,
+      @JsonProperty("containerId") int containerId) {
     this.terms = terms;
     this.containerId = containerId;
   }
@@ -50,11 +53,14 @@ public class QueryComponent {
   }
 
   /**
-   * Converts the provided collection of QueryComponent objects to a map that maps feature categories defined in the query-terms to @{@link QueryContainer} derived from the {@link QueryTerm}.
+   * Converts the provided collection of QueryComponent objects to a map that maps feature
+   * categories defined in the query-terms to @{@link QueryContainer} derived from the {@link
+   * QueryTerm}.
    *
    * @return Category map.
    */
-  public static HashMap<String, ArrayList<QueryContainer>> toCategoryMap(Collection<QueryComponent> components) {
+  public static HashMap<String, ArrayList<QueryContainer>> toCategoryMap(
+      Collection<QueryComponent> components) {
     final HashMap<String, ArrayList<QueryContainer>> categoryMap = new HashMap<>();
     if (components.isEmpty()) {
       LOGGER.warn("Empty components collection, returning empty map");
@@ -87,11 +93,13 @@ public class QueryComponent {
   }
 
   /**
-   * Converts the provided collection of {@link QueryComponent} object to a map of {@link QueryContainer} and their categories.
+   * Converts the provided collection of {@link QueryComponent} object to a map of {@link
+   * QueryContainer} and their categories.
    *
    * @return A map of querycontainers with their associated categories
    */
-  public static HashMap<QueryContainer, List<String>> toContainerMap(Collection<QueryComponent> components) {
+  public static HashMap<QueryContainer, List<String>> toContainerMap(
+      Collection<QueryComponent> components) {
     final HashMap<QueryContainer, List<String>> map = new HashMap<>();
     if (components.isEmpty()) {
       LOGGER.warn("Empty components collection, returning empty list of containers");

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
@@ -7,14 +7,35 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.config.QueryConfig;
 
+/**
+ * A {@link QueryStage} contains a list of {@link QueryTerm}s. This object represents a stage in a
+ * {@link StagedSimilarityQuery}.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 17.02.20
+ */
 public class QueryStage {
 
+  /**
+   * List of {@link QueryTerm}s that are part of this {@link QueryStage}.
+   */
   public final List<QueryTerm> terms;
-  /* may be null */
+
+  /**
+   * The {@link QueryConfig} that should be used to configure the query. May be null!
+   */
   public final QueryConfig config;
 
+  /**
+   * Constructor for the QueryStage object.
+   *
+   * @param terms  List of {@link QueryTerm}s.
+   * @param config The {@link QueryConfig}. May be null!
+   */
   @JsonCreator
-  public QueryStage(@JsonProperty(value = "terms", required = true) List<QueryTerm> terms, @JsonProperty(value = "config", required = false) QueryConfig config) {
+  public QueryStage(@JsonProperty(value = "terms", required = true) List<QueryTerm> terms,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
     this.terms = terms;
     this.config = config;
   }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.config.QueryConfig;
  * {@link StagedSimilarityQuery}.
  *
  * @author silvanheller
- * @version 1.0
  * @created 17.02.20
  */
 public class QueryStage {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
@@ -3,13 +3,14 @@ package org.vitrivr.cineast.api.messages.query;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.query.containers.QueryContainer;
 
-import java.util.List;
-
 /**
+ * Contains the data of a particular {@link QueryTerm}.
+ *
  * @author rgasser
  * @version 1.0
  * @created 11.01.17
@@ -18,7 +19,8 @@ import java.util.List;
 public class QueryTerm {
 
   /**
-   * List of categories defined as part of this {@link QueryTerm}. This ultimately determines the features used for retrieval.
+   * List of categories defined as part of this {@link QueryTerm}. This ultimately determines the
+   * features used for retrieval.
    */
   private final List<String> categories;
 
@@ -28,7 +30,8 @@ public class QueryTerm {
   private final QueryTermType type;
 
   /**
-   * String representation of the query object associated with this query term. Usually base 64 encoded.
+   * String representation of the query object associated with this query term. Usually base 64
+   * encoded.
    */
   private final String data;
 
@@ -43,7 +46,11 @@ public class QueryTerm {
   }
 
   /**
+   * Constructor for the QueryTerm object.
    *
+   * @param type       The {@link QueryTermType} of the {@link QueryTerm}.
+   * @param data       The actual data of the {@link QueryTerm}
+   * @param categories List of categories of the {@link QueryTerm}
    */
   @JsonCreator
   public QueryTerm(@JsonProperty("type") QueryTermType type,
@@ -74,9 +81,12 @@ public class QueryTerm {
 
 
   /**
-   * Converts the {@link QueryTerm} to a {@link QueryContainer} that can be processed by the retrieval pipeline. This includes conversion of query-objects from the Base64 encoded representation.
+   * Converts the {@link QueryTerm} to a {@link QueryContainer} that can be processed by the
+   * retrieval pipeline. This includes conversion of query-objects from the Base64 encoded
+   * representation.
    *
-   * <strong>IMPORTANT:</strong> Subsequent calls to this method return a cached version of the original {@link QueryContainer}.
+   * <strong>IMPORTANT:</strong> Subsequent calls to this method return a cached version of the
+   * original {@link QueryContainer}.
    *
    * @return {@link QueryContainer} representation of the {@link QueryTerm}.
    */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.data.query.containers.QueryContainer;
  * Contains the data of a particular {@link QueryTerm}.
  *
  * @author rgasser
- * @version 1.0
  * @created 11.01.17
  */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTermType.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTermType.java
@@ -18,6 +18,13 @@ import org.vitrivr.cineast.core.data.query.containers.SemanticMapQueryContainer;
 import org.vitrivr.cineast.core.data.query.containers.TagQueryContainer;
 import org.vitrivr.cineast.core.data.query.containers.TextQueryContainer;
 
+/**
+ * A {@link QueryTermType} represents the types of query terms used.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 27.01.17
+ */
 public enum QueryTermType {
 
   IMAGE(ImageQueryContainer.class),
@@ -31,7 +38,8 @@ public enum QueryTermType {
   SEMANTIC(SemanticMapQueryContainer.class),
 
   /**
-   * Denotes a {@link QueryTerm} containing an Id for a 'More-Like-This' query. This is used over the @link {@link MoreLikeThisQuery} in REST calls.
+   * Denotes a {@link QueryTerm} containing an Id for a 'More-Like-This' query. This is used over
+   * the @link {@link MoreLikeThisQuery} in REST calls.
    */
   ID(IdQueryContainer.class),
   BOOLEAN(BooleanQueryContainer.class);
@@ -43,16 +51,25 @@ public enum QueryTermType {
    */
   private final Class<? extends QueryContainer> c;
 
+  /**
+   * Constructor of a class that extends {@link QueryContainer} that represents this {@link
+   * QueryTermType}.
+   */
   QueryTermType(Class<? extends QueryContainer> clazz) {
     this.c = clazz;
   }
 
+  /**
+   * Getter of the Instance of the {@link QueryContainer} class that represents this {@link
+   * QueryTermType}.
+   */
   public Class<? extends QueryContainer> getContainerClass() {
     return this.c;
   }
 
   /**
-   * Constructs a new instance of the {@link QueryContainer} associated with the current {@link QueryTermType} using the provided raw data (usually base 64 encoded).
+   * Constructs a new instance of the {@link QueryContainer} associated with the current {@link
+   * QueryTermType} using the provided raw data (usually base 64 encoded).
    *
    * @param data Data from which to construct a {@link QueryContainer}
    */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTermType.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTermType.java
@@ -22,7 +22,6 @@ import org.vitrivr.cineast.core.data.query.containers.TextQueryContainer;
  * A {@link QueryTermType} represents the types of query terms used.
  *
  * @author rgasser
- * @version 1.0
  * @created 27.01.17
  */
 public enum QueryTermType {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
  * specified.
  *
  * @author rgasser
- * @version 1.0
  * @created 28.12.18
  */
 public class SegmentQuery extends Query {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
@@ -43,9 +43,7 @@ public class SegmentQuery extends Query {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
@@ -34,7 +34,7 @@ public class SegmentQuery extends Query {
   }
 
   /**
-   * Getter for {@link SegmentQuery#segmentId}
+   * Getter for {@link SegmentQuery#segmentId}.
    *
    * @return String
    */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SegmentQuery.java
@@ -2,38 +2,53 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * A {@link SegmentQuery} represents a segment-query message, i.e. a lookup for a segment ID
+ * specified.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 28.12.18
+ */
 public class SegmentQuery extends Query {
 
-    /** ID of the {@link MediaSegmentDescriptor} which should be retrieved. */
-    private final String segmentId;
+  /**
+   * ID of the {@link MediaSegmentDescriptor} which should be retrieved.
+   */
+  private final String segmentId;
 
-    /**
-     * Constructor for {@link SegmentQuery} message.
-     *
-     * @param config The {@link QueryConfig}
-     */
-    @JsonCreator
-    public SegmentQuery(@JsonProperty(value = "segmentId", required = true) String segmentId,
-                        @JsonProperty(value = "config", required = false) QueryConfig config) {
-        super(config);
-        this.segmentId = segmentId;
-    }
+  /**
+   * Constructor for {@link SegmentQuery} message.
+   *
+   * @param config The {@link QueryConfig}
+   */
+  @JsonCreator
+  public SegmentQuery(@JsonProperty(value = "segmentId", required = true) String segmentId,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
+    super(config);
+    this.segmentId = segmentId;
+  }
 
-    /**
-     * Getter for {@link SegmentQuery#segmentId}
-     *
-     * @return
-     */
-    public String getSegmentId() {
-        return segmentId;
-    }
+  /**
+   * Getter for {@link SegmentQuery#segmentId}
+   *
+   * @return String
+   */
+  public String getSegmentId() {
+    return segmentId;
+  }
 
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.Q_SEG;
-    }
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.Q_SEG;
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
@@ -2,48 +2,55 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.vitrivr.cineast.core.config.QueryConfig;
-import org.vitrivr.cineast.core.config.ReadableQueryConfig;
-import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-
 import java.util.List;
+import org.vitrivr.cineast.api.messages.interfaces.MessageType;
+import org.vitrivr.cineast.core.config.QueryConfig;
 
 /**
- * This object represents a similarity-query message, i.e. a request for a similarity-search.
+ * A {@link SimilarityQuery} contains a list of {@link QueryComponent}s. This object represents a
+ * similarity-query message, i.e. a request for a similarity-search.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 27.04.17
  */
 public class SimilarityQuery extends Query {
-    /** List of {@link QueryComponent}s that are part of this {@link SimilarityQuery}. */
-    private List<QueryComponent> components;
 
-    /**
-     * Constructor for the SimilarityQuery object.
-     *
-     * @param components List of {@link QueryComponent}s.
-     * @param config The {@link ReadableQueryConfig}. May be null!
-     */
-    @JsonCreator
-    public SimilarityQuery(@JsonProperty(value = "containers", required = true) List<QueryComponent> components,
-                           @JsonProperty(value = "config", required = false) QueryConfig config) {
-        super(config);
-        this.components = components;
-    }
+  /**
+   * List of {@link QueryComponent}s that are part of this {@link SimilarityQuery}.
+   */
+  private List<QueryComponent> components;
 
-    /**
-     * Getter for containers.
-     *
-     * @return
-     */
-    public List<QueryComponent> getComponents() {
-        return this.components;
-    }
+  /**
+   * Constructor for the SimilarityQuery object.
+   *
+   * @param components List of {@link QueryComponent}s.
+   * @param config     The {@link QueryConfig}. May be null!
+   */
+  @JsonCreator
+  public SimilarityQuery(
+      @JsonProperty(value = "containers", required = true) List<QueryComponent> components,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
+    super(config);
+    this.components = components;
+  }
 
-    /**
-     * Returns the type of particular message. Expressed as MessageTypes enum.
-     *
-     * @return
-     */
-    @Override
-    public MessageType getMessageType() {
-        return MessageType.Q_SIM;
-    }
+  /**
+   * Getter for containers.
+   *
+   * @return List of {@link QueryComponent}
+   */
+  public List<QueryComponent> getComponents() {
+    return this.components;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.Q_SIM;
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.config.QueryConfig;
  * similarity-query message, i.e. a request for a similarity-search.
  *
  * @author rgasser
- * @version 1.0
  * @created 27.04.17
  */
 public class SimilarityQuery extends Query {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/SimilarityQuery.java
@@ -45,9 +45,7 @@ public class SimilarityQuery extends Query {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
@@ -9,7 +9,6 @@ import org.vitrivr.cineast.core.config.QueryConfig;
  * filter for the next one.
  *
  * @author lucaro
- * @version 1.0
  * @created 18.01.20
  */
 public class StagedSimilarityQuery {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
@@ -5,14 +5,33 @@ import java.util.List;
 import org.vitrivr.cineast.core.config.QueryConfig;
 
 /**
- * A {@link StagedSimilarityQuery} contains a list of {@link QueryStage}s. Each of them is used as a filter for the next one.
+ * A {@link StagedSimilarityQuery} contains a list of {@link QueryStage}s. Each of them is used as a
+ * filter for the next one.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 18.01.20
  */
 public class StagedSimilarityQuery {
 
+  /**
+   * List of {@link QueryStage}s that are part of this {@link StagedSimilarityQuery}.
+   */
   public final List<QueryStage> stages;
+
+  /**
+   * The {@link QueryConfig} that should be used to configure the query. May be null!
+   */
   public final QueryConfig config;
 
-  public StagedSimilarityQuery(@JsonProperty(value = "stages", required = true) List<QueryStage> stages,
+  /**
+   * Constructor for the StagedSimilarityQuery object.
+   *
+   * @param stages List of {@link QueryStage}s.
+   * @param config The {@link QueryConfig}. May be null!
+   */
+  public StagedSimilarityQuery(
+      @JsonProperty(value = "stages", required = true) List<QueryStage> stages,
       @JsonProperty(value = "config", required = false) QueryConfig config) {
     this.stages = stages;
     this.config = config;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -6,16 +6,40 @@ import java.util.List;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.config.QueryConfig;
 
+/**
+ * A {@link TemporalQuery} contains a list of {@link StagedSimilarityQuery}s. Each of them
+ * represents a query in a total temporal ordering.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 17.02.20
+ */
 public class TemporalQuery extends Query {
 
+  /**
+   * List of {@link StagedSimilarityQuery}s that are part of this {@link TemporalQuery}.
+   */
   public final List<StagedSimilarityQuery> queries;
 
+  /**
+   * Constructor for the TemporalQuery object.
+   *
+   * @param queries List of {@link StagedSimilarityQuery}s.
+   * @param config  The {@link QueryConfig}. May be null!
+   */
   @JsonCreator
-  public TemporalQuery(@JsonProperty(value = "queries", required = true) List<StagedSimilarityQuery> queries, @JsonProperty(value = "config", required = false) QueryConfig config) {
+  public TemporalQuery(
+      @JsonProperty(value = "queries", required = true) List<StagedSimilarityQuery> queries,
+      @JsonProperty(value = "config", required = false) QueryConfig config) {
     super(config);
     this.queries = queries;
   }
 
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   public MessageType getMessageType() {
     return MessageType.Q_TEMPORAL;
   }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.config.QueryConfig;
  * represents a query in a total temporal ordering.
  *
  * @author silvanheller
- * @version 1.0
  * @created 17.02.20
  */
 public class TemporalQuery extends Query {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -36,9 +36,7 @@ public class TemporalQuery extends Query {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   public MessageType getMessageType() {
     return MessageType.Q_TEMPORAL;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
@@ -7,7 +7,6 @@ import java.util.List;
  * A {@link DistinctElementsResult} contains a list of distinct element IDs.
  *
  * @author silvanheller
- * @version 1.0
  * @created 22.07.20
  */
 public class DistinctElementsResult {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
@@ -2,13 +2,33 @@ package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
-import org.vitrivr.cineast.core.data.tag.Tag;
 
+/**
+ * A {@link DistinctElementsResult} contains a list of distinct element IDs.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 22.07.20
+ */
 public class DistinctElementsResult {
 
+  /**
+   * The query ID to which this distinct elements result belongs.
+   */
   public final String queryId;
+
+  /**
+   * List of distinct elements to be retrieved by a find distinct column request.
+   */
   public final List<String> distinctElements;
 
+  /**
+   * Constructor for the FeaturesTextCategoryQueryResult object.
+   *
+   * @param queryId          String representing the ID of the query to which this part of the
+   *                         result message.
+   * @param distinctElements List of Strings containing distinct elements.
+   */
   @JsonCreator
   public DistinctElementsResult(String queryId, List<String> distinctElements) {
     this.queryId = queryId;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
@@ -9,7 +9,6 @@ import java.util.Map;
  * Used when all features are needed in a single representation.
  *
  * @author silvanheller
- * @version 1.0
  * @created 04.12.20
  */
 public class FeaturesAllCategoriesQueryResult {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
@@ -3,25 +3,45 @@ package org.vitrivr.cineast.api.messages.result;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Map;
 
-
 /**
- * content: Map of all feature categories such as tags, captions, OCR, ASR etc. with their values. Used when all features are needed in a single representation
+ * A {@link FeaturesAllCategoriesQueryResult} contains a list of Strings as content of the result
+ * message. Map of all feature categories such as tags, captions, OCR, ASR etc. with their values.
+ * Used when all features are needed in a single representation.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 04.12.20
  */
 public class FeaturesAllCategoriesQueryResult {
 
-  public final String queryId;
   /**
-   * <category, all features for this category and the given id>
+   * The query ID to which this features all categories query result belongs.
+   */
+  public final String queryId;
+
+  /**
+   * Map that maps categories to all features for this category.
    */
   public final Map<String, Object[]> featureMap;
 
   /**
-   * can refer to anything with an ID (i.e. segment, object)
+   * The element for which the feature values were requested. can refer to anything with an ID (i.e.
+   * segment, object).
    */
   public final String elementID;
 
+  /**
+   * Constructor for the FeaturesTextCategoryQueryResult object.
+   *
+   * @param queryId    String representing the ID of the query to which this part of the result
+   *                   message.
+   * @param featureMap Map that maps strings to all features for this category for a given element
+   *                   ID.
+   * @param elementID  Element for which the feature values were requested.
+   */
   @JsonCreator
-  public FeaturesAllCategoriesQueryResult(String queryId, Map<String, Object[]> featureMap, String elementID) {
+  public FeaturesAllCategoriesQueryResult(String queryId, Map<String, Object[]> featureMap,
+      String elementID) {
     this.queryId = queryId;
     this.featureMap = featureMap;
     this.elementID = elementID;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
@@ -9,7 +9,6 @@ import java.util.List;
  * String features (e.g. OCR, ASR) queries.
  *
  * @author silvanheller
- * @version 1.0
  * @created 04.12.20
  */
 public class FeaturesTextCategoryQueryResult {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
@@ -4,17 +4,50 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
 
 /**
- * All features for a given category and element (i.e. segment, object). Only used for String features (e.g. OCR, ASR)
+ * A {@link FeaturesTextCategoryQueryResult} contains a list of Strings as content of the result
+ * message. All features for a given category and element (i.e. segment, object). Only used for
+ * String features (e.g. OCR, ASR) queries.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 04.12.20
  */
 public class FeaturesTextCategoryQueryResult {
 
+  /**
+   * The query ID to which this features text category query result belongs.
+   */
   public final String queryId;
+
+  /**
+   * List of features that belong to a given category and element.
+   */
   public final List<String> featureValues;
+
+  /**
+   * The category for which the feature values were requested.
+   */
   public final String category;
+
+  /**
+   * The element for which the feature values were requested. can refer to anything with an ID (i.e.
+   * segment, object).
+   */
   public final String elementID;
 
+  /**
+   * Constructor for the FeaturesTextCategoryQueryResult object.
+   *
+   * @param queryId       String representing the ID of the query to which this part of the result
+   *                      message.
+   * @param featureValues List of Strings containing the feature values for the given element and
+   *                      category.
+   * @param category      Category for which the feature values were requested.
+   * @param elementID     Element for which the feature values were requested.
+   */
   @JsonCreator
-  public FeaturesTextCategoryQueryResult(String queryId, List<String> featureValues, String category, String elementID) {
+  public FeaturesTextCategoryQueryResult(String queryId, List<String> featureValues,
+      String category, String elementID) {
     this.queryId = queryId;
     this.featureValues = featureValues;
     this.category = category;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
  * queries.
  *
  * @author rgasser
- * @version 1.0
  * @created 14.02.17
  */
 public class MediaObjectMetadataQueryResult extends

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
@@ -1,19 +1,42 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
-import java.util.List;
+/**
+ * A {@link MediaSegmentMetadataQueryResult} contains a list of {@link
+ * MediaObjectMetadataDescriptor}s as content of the result message. It is part of a response for
+ * queries.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 14.02.17
+ */
+public class MediaObjectMetadataQueryResult extends
+    AbstractQueryResultMessage<MediaObjectMetadataDescriptor> {
 
-public class MediaObjectMetadataQueryResult extends AbstractQueryResultMessage<MediaObjectMetadataDescriptor> {
-
+  /**
+   * Constructor for the MediaObjectMetadataQueryResult object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param content List of {@link MediaObjectMetadataDescriptor} of the metadata descriptors of
+   *                objects belonging to to a query response.
+   */
   @JsonCreator
-  public MediaObjectMetadataQueryResult(String queryId, List<MediaObjectMetadataDescriptor> content) {
+  public MediaObjectMetadataQueryResult(String queryId,
+      List<MediaObjectMetadataDescriptor> content) {
     super(queryId, MediaObjectMetadataDescriptor.class, content);
   }
 
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_METADATA_O;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
@@ -33,9 +33,7 @@ public class MediaObjectMetadataQueryResult extends
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
  * the result message. It is part of a response for queries.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public class MediaObjectQueryResult extends AbstractQueryResultMessage<MediaObjectDescriptor> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
@@ -1,19 +1,39 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 
-import java.util.List;
-
+/**
+ * A {@link MediaObjectQueryResult} contains a list of {@link MediaObjectDescriptor}s as content of
+ * the result message. It is part of a response for queries.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
+ */
 public class MediaObjectQueryResult extends AbstractQueryResultMessage<MediaObjectDescriptor> {
 
+  /**
+   * Constructor for the SimilarityQueryResult object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param content List of {@link MediaObjectDescriptor} of the objects belonging to to a query
+   *                response.
+   */
   @JsonCreator
   public MediaObjectQueryResult(String queryId, List<MediaObjectDescriptor> content) {
     super(queryId, MediaObjectDescriptor.class, content);
   }
 
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_OBJECT;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
@@ -30,9 +30,7 @@ public class MediaObjectQueryResult extends AbstractQueryResultMessage<MediaObje
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
@@ -33,9 +33,7 @@ public class MediaSegmentMetadataQueryResult extends
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
@@ -6,13 +6,37 @@ import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentMetadataDescriptor;
 
-public class MediaSegmentMetadataQueryResult extends AbstractQueryResultMessage<MediaSegmentMetadataDescriptor> {
+/**
+ * A {@link MediaSegmentMetadataQueryResult} contains a list of {@link
+ * MediaSegmentMetadataDescriptor}s as content of the result message. It is part of a response for
+ * queries.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 14.02.17
+ */
+public class MediaSegmentMetadataQueryResult extends
+    AbstractQueryResultMessage<MediaSegmentMetadataDescriptor> {
 
-    @JsonCreator
-    public MediaSegmentMetadataQueryResult(String queryId, List<MediaSegmentMetadataDescriptor> content) {
-        super(queryId, MediaSegmentMetadataDescriptor.class, content);
-    }
+  /**
+   * Constructor for the MediaSegmentMetadataQueryResult object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param content List of {@link MediaSegmentMetadataDescriptor} of the metadata descriptors of
+   *                segments belonging to to a query response.
+   */
+  @JsonCreator
+  public MediaSegmentMetadataQueryResult(String queryId,
+      List<MediaSegmentMetadataDescriptor> content) {
+    super(queryId, MediaSegmentMetadataDescriptor.class, content);
+  }
 
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_METADATA_S;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.data.entities.MediaSegmentMetadataDescriptor;
  * queries.
  *
  * @author rgasser
- * @version 1.0
  * @created 14.02.17
  */
 public class MediaSegmentMetadataQueryResult extends

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
@@ -30,9 +30,7 @@ public class MediaSegmentQueryResult extends AbstractQueryResultMessage<MediaSeg
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
  * of the result message. It is part of a response for queries.
  *
  * @author rgasser
- * @version 1.0
  * @created 12.01.17
  */
 public class MediaSegmentQueryResult extends AbstractQueryResultMessage<MediaSegmentDescriptor> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
@@ -1,29 +1,43 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
 
-import java.util.List;
-
 /**
+ * A {@link MediaSegmentQueryResult} contains a list of {@link MediaSegmentDescriptor}s as content
+ * of the result message. It is part of a response for queries.
+ *
  * @author rgasser
+ * @version 1.0
  * @created 12.01.17
  */
 public class MediaSegmentQueryResult extends AbstractQueryResultMessage<MediaSegmentDescriptor> {
+
   /**
-   * @param content
+   * Constructor for the SimilarityQueryResult object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param content List of {@link MediaSegmentDescriptor} of the segments belonging to to a query
+   *                response.
    */
   @JsonCreator
   public MediaSegmentQueryResult(String queryId, List<MediaSegmentDescriptor> content) {
     super(queryId, MediaSegmentDescriptor.class, content);
   }
-  
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_SEGMENT;
   }
-  
-  
+
+
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
@@ -3,21 +3,47 @@ package org.vitrivr.cineast.api.messages.result;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * Message for a query result end to communicate the end of a query result.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
+ */
 public class QueryEnd implements Message {
 
+  /**
+   * The query ID to which this query start message belongs.
+   */
   private final String queryId;
 
+  /**
+   * Constructor for the QueryEnd object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   */
   public QueryEnd(String queryId) {
     this.queryId = queryId;
   }
 
+  /**
+   * Getter for queryId.
+   *
+   * @return String
+   */
+  public String getQueryId() {
+    return queryId;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_END;
-  }
-
-  public String getQueryId() {
-    return queryId;
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
@@ -7,7 +7,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message for a query result end to communicate the end of a query result.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public class QueryEnd implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
@@ -37,9 +37,7 @@ public class QueryEnd implements Message {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
@@ -3,34 +3,63 @@ package org.vitrivr.cineast.api.messages.result;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * Message for a query error to communicate an error occurred during querying.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 03.06.17
+ */
 public class QueryError implements Message {
 
   /**
-   * ID of the query.
+   * The query ID to which this query start message belongs.
    */
   private final String queryId;
 
   /**
-   * Error message.
+   * The error message to communicate the error occurred.
    */
   private final String message;
 
+  /**
+   * Constructor for the QueryError object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param message String representing the error message.
+   */
   public QueryError(String queryId, String message) {
     this.queryId = queryId;
     this.message = message;
   }
 
-  @Override
-  public MessageType getMessageType() {
-    return MessageType.QR_ERROR;
-  }
-
+  /**
+   * Getter for queryId.
+   *
+   * @return String
+   */
   public String getQueryId() {
     return queryId;
   }
 
+  /**
+   * Getter for error message.
+   *
+   * @return String
+   */
   public String getErrorMessage() {
     return this.message;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
+  @Override
+  public MessageType getMessageType() {
+    return MessageType.QR_ERROR;
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
@@ -7,7 +7,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message for a query error to communicate an error occurred during querying.
  *
  * @author rgasser
- * @version 1.0
  * @created 03.06.17
  */
 public class QueryError implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
@@ -53,9 +53,7 @@ public class QueryError implements Message {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
@@ -7,7 +7,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message for a query result start to establish the context of the following messages.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public class QueryStart implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
@@ -38,9 +38,7 @@ public class QueryStart implements Message {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
@@ -3,27 +3,48 @@ package org.vitrivr.cineast.api.messages.result;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * Message for a query result start to establish the context of the following messages.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 22.01.17
+ */
 public class QueryStart implements Message {
 
   /**
-   * Unique ID of the QueryStart message. This ID establishes a context which is important for all further communication.
+   * The query ID to which this query start message belongs. Unique ID of the QueryStart message.
+   * This ID establishes a context which is important for all further communication.
    */
   private final String queryId;
 
   /**
-   * Default constructor; generates the QueryId as random UUID.
+   * Constructor for the QueryStart object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
    */
   public QueryStart(String queryId) {
     this.queryId = queryId;
   }
 
+  /**
+   * Getter for queryId.
+   *
+   * @return String
+   */
+  public String getQueryId() {
+    return queryId;
+  }
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_START;
-  }
-
-  public String getQueryId() {
-    return queryId;
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
@@ -1,41 +1,79 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.StringDoublePair;
 
-import java.util.List;
-
 /**
+ * A {@link SimilarityQueryResult} contains a list of {@link StringDoublePair}s as content of the
+ * result message. It is a response for a similarity query as well as a temporal query as a result
+ * of a temporal container.
+ *
  * @author rgasser
+ * @version 1.0
  * @created 11.01.17
  */
 public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoublePair> {
-  
+
+  /**
+   * The category to which the content of this similarity query result belong.
+   */
   private String category;
+
+  /**
+   * The container which this similarity query result belongs. Important for the temporal queries
+   * with more than one containers chained in a total temporal order.
+   */
   private int containerId;
 
+  /**
+   * Constructor for the SimilarityQueryResult object.
+   *
+   * @param queryId     String representing the ID of the query to which this part of the result
+   *                    message.
+   * @param category    String category to which this result belongs.
+   * @param containerId int id of the temporal container to which this result belongs.
+   * @param content     List of {@link StringDoublePair} of the segments belonging to this result
+   *                    with their respective score.
+   */
   @JsonCreator
-  public SimilarityQueryResult(String queryId, String category, int containerId, List<StringDoublePair> content) {
+  public SimilarityQueryResult(String queryId, String category, int containerId,
+      List<StringDoublePair> content) {
     super(queryId, StringDoublePair.class, content);
     this.category = category;
     this.containerId = containerId;
   }
-  
+
+  /**
+   * Getter for container id.
+   *
+   * @return int
+   */
   public int getContainerId() {
     return this.containerId;
   }
-  
+
+  /**
+   * Getter for category.
+   *
+   * @return String
+   */
   public String getCategory() {
     return category;
   }
-  
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_SIMILARITY;
   }
-  
+
   @Override
   public String toString() {
     return "SimilarityQueryResult{" +

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
@@ -12,7 +12,6 @@ import org.vitrivr.cineast.core.data.StringDoublePair;
  * of a temporal container.
  *
  * @author rgasser
- * @version 1.0
  * @created 11.01.17
  */
 public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoublePair> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
@@ -65,9 +65,7 @@ public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoub
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
@@ -11,7 +11,6 @@ import org.vitrivr.cineast.core.data.StringDoublePair;
  * of the result message. It combines several results to be posted to the API.
  *
  * @author lucaro
- * @version 1.0
  * @created 12.05.17
  */
 public class SimilarityQueryResultBatch {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
@@ -6,17 +6,48 @@ import java.util.HashMap;
 import java.util.List;
 import org.vitrivr.cineast.core.data.StringDoublePair;
 
+/**
+ * A {@link SimilarityQueryResultBatch} contains a list of {@link SimilarityQueryResult}s as content
+ * of the result message. It combines several results to be posted to the API.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 12.05.17
+ */
 public class SimilarityQueryResultBatch {
 
+  /**
+   * List of categories to which the content of this similarity query result belong.
+   */
   private List<String> categories;
+
+  /**
+   * List of {@link SimilarityQueryResult} that are part of this similarity result batch.
+   */
   private List<SimilarityQueryResult> results;
 
+  /**
+   * Constructor for the SimilarityQueryResult object with the results already in the right format
+   * of a list of {@link SimilarityQueryResult}.
+   *
+   * @param categories List of Strings representing the categories of the similarity query results.
+   * @param results    List of {@link SimilarityQueryResult} that are results of the query.
+   */
   @JsonCreator
   public SimilarityQueryResultBatch(List<String> categories, List<SimilarityQueryResult> results) {
     this.categories = categories;
     this.results = results;
   }
 
+  /**
+   * Constructor for the SimilarityQueryResult object with the results in the form of a map mapping
+   * categories to results which are filled into the local variables in the right format.
+   *
+   * @param map     Map of Strings mapped to Lists of {@link StringDoublePair} where categories are
+   *                mapped to the results of the similarity query.
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   */
   public SimilarityQueryResultBatch(HashMap<String, List<StringDoublePair>> map, String queryId) {
     this(new ArrayList<>(map.keySet()), new ArrayList<>(map.size()));
     for (String category : this.categories) {
@@ -24,10 +55,20 @@ public class SimilarityQueryResultBatch {
     }
   }
 
+  /**
+   * Getter for categories.
+   *
+   * @return List of String
+   */
   public List<String> getCategories() {
     return this.categories;
   }
 
+  /**
+   * Getter for results.
+   *
+   * @return List of {@link SimilarityQueryResult}
+   */
   public List<SimilarityQueryResult> getResults() {
     return this.results;
   }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
@@ -2,14 +2,41 @@ package org.vitrivr.cineast.api.messages.result;
 
 import java.util.List;
 
+/**
+ * General-purpose result for any query that expects a list of tag IDs for an element ID as a
+ * result.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 04.12.20
+ */
 public class TagIDsForElementQueryResult {
 
+  /**
+   * The query ID to which this tags query result belongs.
+   */
   public final String queryId;
 
+  /**
+   * List of tag IDs that represent the result of the tags query.
+   */
   public final List<String> tagIDs;
 
+  /**
+   * The element ID to which the tag IDs have been retrieved.
+   */
   public final String elementID;
 
+  /**
+   * Constructor for the TagIDsForElementQueryResult object.
+   *
+   * @param queryId   String representing the ID of the query to which this part of the result
+   *                  message.
+   * @param tags      List of Strings containing the tag IDs that belong to the element ID and
+   *                  represent the result of the query.
+   * @param elementID String representing the element ID of the element of which the tag IDs were
+   *                  looked up for.
+   */
   public TagIDsForElementQueryResult(String queryId, List<String> tags, String elementID) {
     this.queryId = queryId;
     this.tagIDs = tags;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
@@ -7,7 +7,6 @@ import java.util.List;
  * result.
  *
  * @author silvanheller
- * @version 1.0
  * @created 04.12.20
  */
 public class TagIDsForElementQueryResult {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
@@ -8,7 +8,6 @@ import org.vitrivr.cineast.core.data.tag.Tag;
  * General-purpose result for any query that expects a list of tags as a result.
  *
  * @author sauterl
- * @version 1.0
  * @created 06.05.20
  */
 public class TagsQueryResult {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
@@ -1,18 +1,35 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import org.vitrivr.cineast.core.data.tag.Tag;
 
-import java.util.List;
-
 /**
- * General-purpose result for any query that expects a list of tags as a result
+ * General-purpose result for any query that expects a list of tags as a result.
+ *
+ * @author sauterl
+ * @version 1.0
+ * @created 06.05.20
  */
 public class TagsQueryResult {
-  
+
+  /**
+   * The query ID to which this tags query result belongs.
+   */
   public final String queryId;
+
+  /**
+   * List of tags that represent the result of the tags query.
+   */
   public final List<Tag> tags;
-  
+
+  /**
+   * Constructor for the TagsQueryResult object.
+   *
+   * @param queryId String representing the ID of the query to which this part of the result
+   *                message.
+   * @param tags    List of Strings containing the tags that represent the result of the query.
+   */
   @JsonCreator
   public TagsQueryResult(String queryId, List<Tag> tags) {
     this.queryId = queryId;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
@@ -3,44 +3,77 @@ package org.vitrivr.cineast.api.messages.session;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Arrays;
 import java.util.List;
-
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
 
 /**
- * @author silvan on 22.01.18.
+ * This object represents a response to an extract item query and contains {@link
+ * ExtractionItemContainer} as a body to be returned in the response message.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 22.01.18
  */
 public class ExtractionContainerMessage implements Message {
-  
+
+  /**
+   * List of {@link ExtractionItemContainer} items that are part of this extraction container
+   * message.
+   */
   private List<ExtractionItemContainer> items;
-  
+
+  /**
+   * Constructor for the ExtractionContainerMessage object.
+   *
+   * @param items Items that should be sent back with this message.
+   */
   public ExtractionContainerMessage(ExtractionItemContainer[] items) {
     this.items = Arrays.asList(items);
   }
-  
+
+  /**
+   * Constructor for the ExtractionContainerMessage object able to create a JSON file from an
+   * instance of this class created by this constructor.
+   *
+   * @param items Items that should be sent back with this message.
+   */
   @JsonCreator
   public ExtractionContainerMessage(@JsonProperty("items") List<ExtractionItemContainer> items) {
     this.items = items;
   }
-  
+
+  /**
+   * Getter for items.
+   *
+   * @return @return List of {@link ExtractionItemContainer}
+   */
   public List<ExtractionItemContainer> getItems() {
     return this.items;
   }
-  
+
+  /**
+   * Getter for items as an Array.
+   *
+   * @return @return Array of {@link ExtractionItemContainer}
+   */
   @JsonIgnore
   public ExtractionItemContainer[] getItemsAsArray() {
     return this.items.toArray(new ExtractionItemContainer[0]);
   }
-  
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return null;
   }
-  
+
   @Override
   public String toString() {
     return "ExtractionContainerMessage{" +

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
@@ -10,8 +10,8 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
 
 /**
- * This object represents a response to an extract item query and contains {@link
- * ExtractionItemContainer} as a body to be returned in the response message.
+ * This object represents a container for multiple extract item requests and contains {@link
+ * ExtractionItemContainer} as a body of the message.
  *
  * @author silvanheller
  * @version 1.0
@@ -65,9 +65,7 @@ public class ExtractionContainerMessage implements Message {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
@@ -14,7 +14,6 @@ import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
  * ExtractionItemContainer} as a body of the message.
  *
  * @author silvanheller
- * @version 1.0
  * @created 22.01.18
  */
 public class ExtractionContainerMessage implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
@@ -2,46 +2,91 @@ package org.vitrivr.cineast.api.messages.session;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.session.Session;
 import org.vitrivr.cineast.api.session.SessionType;
 
+/**
+ * This object stores the session state of a request to both the WebSocket and RESTful API.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 08.05.17
+ */
 public class SessionState {
 
+  /**
+   * Unique ID of the session.
+   */
   private String id;
+
+  /**
+   * Unix time until this session becomes expired.
+   */
   private long validUntil;
+
+  /**
+   * Type of the session to identify the access rights of the session user. Restricted to the {@link
+   * SessionType} enum types.
+   */
   private SessionType type;
-  
+
+  /**
+   * Constructor for the SessionState object.
+   *
+   * @param id         Unique session id.
+   * @param validUntil Time until session becomes invalid.
+   * @param type       Type of the session used to determine access rights.
+   */
   @JsonCreator
-  public SessionState(@JsonProperty("id")String id, @JsonProperty("validUntil")long validUntil, @JsonProperty("type")SessionType type){
+  public SessionState(@JsonProperty("id") String id, @JsonProperty("validUntil") long validUntil,
+      @JsonProperty("type") SessionType type) {
     this.id = id;
     this.validUntil = validUntil;
     this.type = type;
   }
-  
-  public SessionState(Session session){
+
+  /**
+   * Constructor for the SessionState object from a previously created Session.
+   *
+   * @param session Previously created session with the same properties as this session state.
+   */
+  public SessionState(Session session) {
     this(session.getSessionId(), session.getEndTimeStamp(), session.getSessionType());
   }
-  
-  public String getSessionId(){
+
+  /**
+   * Getter for session ID.
+   *
+   * @return String
+   */
+  public String getSessionId() {
     return this.id;
   }
-  
-  public long getValidUntil(){
+
+  /**
+   * Getter for validUntil.
+   *
+   * @return long
+   */
+  public long getValidUntil() {
     return this.validUntil;
   }
-  
-  public SessionType getType(){
+
+  /**
+   * Getter for session type.
+   *
+   * @return {@link SessionType}
+   */
+  public SessionType getType() {
     return this.type;
   }
 
   @Override
   public String toString() {
     return "SessionState{" +
-            "id='" + id + '\'' +
-            ", validUntil=" + validUntil +
-            ", type=" + type +
-            '}';
+        "id='" + id + '\'' +
+        ", validUntil=" + validUntil +
+        ", type=" + type +
+        '}';
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
@@ -9,7 +9,6 @@ import org.vitrivr.cineast.api.session.SessionType;
  * This object stores the session state of a session with a requester.
  *
  * @author lucaro
- * @version 1.0
  * @created 08.05.17
  */
 public class SessionState {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
@@ -6,7 +6,7 @@ import org.vitrivr.cineast.api.session.Session;
 import org.vitrivr.cineast.api.session.SessionType;
 
 /**
- * This object stores the session state of a request to both the WebSocket and RESTful API.
+ * This object stores the session state of a session with a requester.
  *
  * @author lucaro
  * @version 1.0

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
@@ -10,7 +10,6 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
  * Message from the requester to transfer the access credentials of the current session.
  *
  * @author lucaro
- * @version 1.0
  * @created 08.05.17
  */
 public class StartSessionMessage implements Message {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
@@ -7,7 +7,7 @@ import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
 /**
- * Message to the requester to transfer the access credentials of the current session.
+ * Message from the requester to transfer the access credentials of the current session.
  *
  * @author lucaro
  * @version 1.0
@@ -23,7 +23,7 @@ public class StartSessionMessage implements Message {
   /**
    * Constructor for the StartSessionMessage object.
    *
-   * @param credentials Credentials of the current session to be sent to the requester.
+   * @param credentials Credentials of the current session from the user.
    */
   @JsonCreator
   public StartSessionMessage(@JsonProperty("credentials") Credentials credentials) {
@@ -40,9 +40,7 @@ public class StartSessionMessage implements Message {
   }
 
   /**
-   * Returns the type of particular message. Expressed as MessageTypes enum.
-   *
-   * @return {@link MessageType}
+   * {@inheritDoc}
    */
   @Override
   public MessageType getMessageType() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
@@ -6,19 +6,44 @@ import org.vitrivr.cineast.api.messages.credentials.Credentials;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
+/**
+ * Message to the requester to transfer the access credentials of the current session.
+ *
+ * @author lucaro
+ * @version 1.0
+ * @created 08.05.17
+ */
 public class StartSessionMessage implements Message {
 
+  /**
+   * {@link Credentials} of the session with the user.
+   */
   private Credentials credentials;
-  
+
+  /**
+   * Constructor for the StartSessionMessage object.
+   *
+   * @param credentials Credentials of the current session to be sent to the requester.
+   */
   @JsonCreator
-  public StartSessionMessage(@JsonProperty("credentials")Credentials credentials){
+  public StartSessionMessage(@JsonProperty("credentials") Credentials credentials) {
     this.credentials = credentials;
   }
-  
-  public Credentials getCredentials(){
+
+  /**
+   * Getter for credentials.
+   *
+   * @return {@link Credentials}
+   */
+  public Credentials getCredentials() {
     return this.credentials;
   }
-  
+
+  /**
+   * Returns the type of particular message. Expressed as MessageTypes enum.
+   *
+   * @return {@link MessageType}
+   */
   @Override
   public MessageType getMessageType() {
     return MessageType.SESSION_START;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/WebsocketAPI.java
@@ -1,9 +1,21 @@
 package org.vitrivr.cineast.api.websocket;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.*;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.vitrivr.cineast.api.APIEndpoint;
 import org.vitrivr.cineast.api.messages.general.AnyMessage;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
@@ -11,115 +23,131 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.api.websocket.handlers.MetadataLookupMessageHandler;
 import org.vitrivr.cineast.api.websocket.handlers.StatusMessageHandler;
 import org.vitrivr.cineast.api.websocket.handlers.interfaces.WebsocketMessageHandler;
-import org.vitrivr.cineast.api.websocket.handlers.queries.*;
+import org.vitrivr.cineast.api.websocket.handlers.queries.MoreLikeThisQueryMessageHandler;
+import org.vitrivr.cineast.api.websocket.handlers.queries.NeighbouringQueryMessageHandler;
+import org.vitrivr.cineast.api.websocket.handlers.queries.SegmentQueryMessageHandler;
+import org.vitrivr.cineast.api.websocket.handlers.queries.SimilarityQueryMessageHandler;
+import org.vitrivr.cineast.api.websocket.handlers.queries.TemporalQueryMessageHandler;
 import org.vitrivr.cineast.core.util.LogHelper;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 import org.vitrivr.cineast.standalone.config.Config;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Queue;
-import java.util.concurrent.*;
-
 
 /**
- * This class establishes a WebSocket endpoint listening on the specified port. Incoming messages are expected
- * to come in a JSON format and to have an application specific POJO representation. This class maps those messages
- * to such a POJO and routes them towards a WebsocketMessageHandler provided that such a handler has been registered.
+ * This class establishes a WebSocket endpoint listening on the specified port. Incoming messages
+ * are expected to come in a JSON format and to have an application specific POJO representation.
+ * This class maps those messages to such a POJO and routes them towards a WebsocketMessageHandler
+ * provided that such a handler has been registered.
  *
  * @see WebsocketMessageHandler
  * @see Message
- *
  */
 @WebSocket
 public class WebsocketAPI {
 
-    /** Logging facility. */
-    private static final Logger LOGGER = LogManager.getLogger();
+  /**
+   * Logging facility.
+   */
+  private static final Logger LOGGER = LogManager.getLogger();
 
-    /** Store SESSIONS if you want to, for example, broadcast a message to all users.*/
-    private static final Queue<Session> SESSIONS = new ConcurrentLinkedQueue<>();
+  /**
+   * Store SESSIONS if you want to, for example, broadcast a message to all users.
+   */
+  private static final Queue<Session> SESSIONS = new ConcurrentLinkedQueue<>();
 
-    /** A cached ThreadPoolExecutor used to execute tasks submitted and handled by the WebSocket API */
-    private static final ExecutorService EXECUTORS = new ThreadPoolExecutor(2,Integer.MAX_VALUE,60L,TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+  /**
+   * A cached ThreadPoolExecutor used to execute tasks submitted and handled by the WebSocket API
+   */
+  private static final ExecutorService EXECUTORS = new ThreadPoolExecutor(2, Integer.MAX_VALUE, 60L,
+      TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
 
-    /** List of stateless {@link WebsocketMessageHandler} classes for the API. */
-    private static final HashMap<MessageType, WebsocketMessageHandler<?>> STATELESS_HANDLERS = new HashMap<>();
-    static {
-        STATELESS_HANDLERS.put(MessageType.Q_SIM, new SimilarityQueryMessageHandler(APIEndpoint.retrievalLogic));
-        STATELESS_HANDLERS.put(MessageType.Q_TEMPORAL, new TemporalQueryMessageHandler(APIEndpoint.retrievalLogic));
-        STATELESS_HANDLERS.put(MessageType.Q_MLT, new MoreLikeThisQueryMessageHandler(APIEndpoint.retrievalLogic));
-        STATELESS_HANDLERS.put(MessageType.Q_NESEG, new NeighbouringQueryMessageHandler());
-        STATELESS_HANDLERS.put(MessageType.Q_SEG, new SegmentQueryMessageHandler());
-        STATELESS_HANDLERS.put(MessageType.PING, new StatusMessageHandler());
-        STATELESS_HANDLERS.put(MessageType.M_LOOKUP, new MetadataLookupMessageHandler());
+  /**
+   * List of stateless {@link WebsocketMessageHandler} classes for the API.
+   */
+  private static final HashMap<MessageType, WebsocketMessageHandler<?>> STATELESS_HANDLERS = new HashMap<>();
+
+  static {
+    STATELESS_HANDLERS
+        .put(MessageType.Q_SIM, new SimilarityQueryMessageHandler(APIEndpoint.retrievalLogic));
+    STATELESS_HANDLERS
+        .put(MessageType.Q_TEMPORAL, new TemporalQueryMessageHandler(APIEndpoint.retrievalLogic));
+    STATELESS_HANDLERS
+        .put(MessageType.Q_MLT, new MoreLikeThisQueryMessageHandler(APIEndpoint.retrievalLogic));
+    STATELESS_HANDLERS.put(MessageType.Q_NESEG, new NeighbouringQueryMessageHandler());
+    STATELESS_HANDLERS.put(MessageType.Q_SEG, new SegmentQueryMessageHandler());
+    STATELESS_HANDLERS.put(MessageType.PING, new StatusMessageHandler());
+    STATELESS_HANDLERS.put(MessageType.M_LOOKUP, new MetadataLookupMessageHandler());
+  }
+
+  /* */
+  private JacksonJsonProvider reader = new JacksonJsonProvider();
+
+  /**
+   * Shuts down this WebsocketAPIs ThreadPoolExecutor.
+   */
+  public void shutdown() {
+    EXECUTORS.shutdown();
+    try {
+      EXECUTORS.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
+    EXECUTORS.shutdownNow();
+  }
 
-    /* */
-    private JacksonJsonProvider reader = new JacksonJsonProvider();
+  /**
+   * Invoked whenever a new connection is established. Configures the session and stashes it in the
+   * {@link WebsocketAPI#SESSIONS} map.
+   *
+   * @param session Session associated with the new connection.
+   */
+  @OnWebSocketConnect
+  public void connected(Session session) {
+    session.getPolicy().setMaxTextMessageSize(Config.sharedConfig().getApi().getMaxMessageSize());
+    session.getPolicy().setMaxBinaryMessageSize(Config.sharedConfig().getApi().getMaxMessageSize());
+    SESSIONS.add(session);
+    LOGGER.debug("New session {} connected!", session.getRemoteAddress().toString());
+  }
 
-    /**
-     * Shuts down this WebsocketAPIs ThreadPoolExecutor.
-     */
-    public void shutdown() {
-        EXECUTORS.shutdown();
-        try {
-            EXECUTORS.awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        EXECUTORS.shutdownNow();
-    }
- 
-    /**
-     * Invoked whenever a new connection is established. Configures the session and stashes it in the {@link WebsocketAPI#SESSIONS} map.
-     *
-     * @param session Session associated with the new connection.
-     */
-    @OnWebSocketConnect
-    public void connected(Session session) {
-        session.getPolicy().setMaxTextMessageSize(Config.sharedConfig().getApi().getMaxMessageSize());
-        session.getPolicy().setMaxBinaryMessageSize(Config.sharedConfig().getApi().getMaxMessageSize());
-        SESSIONS.add(session);
-        LOGGER.debug("New session {} connected!", session.getRemoteAddress().toString());
-    }
+  /**
+   * Invoked whenever a new connection is closed. Removes the session from the {@link
+   * WebsocketAPI#SESSIONS} map.
+   *
+   * @param session Session associated with the new connection.
+   */
+  @OnWebSocketClose
+  public void closed(Session session, int statusCode, String reason) {
+    SESSIONS.remove(session);
+    LOGGER.debug("Connection of session closed (Code: {}, Reason: {}).", statusCode, reason);
+  }
 
-    /**
-     * Invoked whenever a new connection is closed. Removes the session from the {@link WebsocketAPI#SESSIONS} map.
-     *
-     * @param session Session associated with the new connection.
-     */
-    @OnWebSocketClose
-    public void closed(Session session, int statusCode, String reason) {
-        SESSIONS.remove(session);
-        LOGGER.debug("Connection of session closed (Code: {}, Reason: {}).", statusCode, reason);
-    }
+  /*
+   * TODO: Handle errors properly.
+   */
+  @OnWebSocketError
+  public void onWebSocketException(Session session, Throwable error) {
+    LOGGER.fatal("An unhandled error occurred during message handling: {}",
+        LogHelper.getStackTrace(error));
+  }
 
-    /*
-     * TODO: Handle errors properly.
-     */
-    @OnWebSocketError
-    public void onWebSocketException(Session session, Throwable error) {
-        LOGGER.fatal("An unhandled error occurred during message handling: {}", LogHelper.getStackTrace(error));
+  /**
+   * Handles incoming messages. This method determines the message-type of the message. If that type
+   * is known, the message is routed to a pre-registered message handler.
+   *
+   * @param session Session the message belongs to.
+   * @param message String message.
+   */
+  @OnWebSocketMessage
+  @SuppressWarnings("unchecked")
+  public void message(Session session, String message) throws IOException {
+    final AnyMessage testMessage = this.reader.toObject(message, AnyMessage.class);
+    if (testMessage != null) {
+      final MessageType type = testMessage.getMessageType();
+      final WebsocketMessageHandler handler = STATELESS_HANDLERS.get(type);
+      if (handler != null) {
+        EXECUTORS.execute(
+            () -> handler.handle(session, this.reader.toObject(message, type.getMessageClass())));
+      }
     }
-
-    /**
-     * Handles incoming messages. This method determines the message-type of the message. If
-     * that type is known, the message is routed to a pre-registered message handler.
-     *
-     * @param session Session the message belongs to.
-     * @param message String message.
-     */
-    @OnWebSocketMessage
-    @SuppressWarnings("unchecked")
-    public void message(Session session, String message) throws IOException {
-        final AnyMessage testMessage = this.reader.toObject(message, AnyMessage.class);
-        if (testMessage != null) {
-            final MessageType type = testMessage.getMessageType();
-            final WebsocketMessageHandler handler = STATELESS_HANDLERS.get(type);
-            if (handler != null) {
-                EXECUTORS.execute(() -> handler.handle(session, this.reader.toObject(message, type.getMessageClass())));
-            }
-        }
-    }
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/MetadataLookupMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/MetadataLookupMessageHandler.java
@@ -14,7 +14,6 @@ import org.vitrivr.cineast.standalone.config.Config;
  * messages of type {@link MetadataLookup}.
  *
  * @author rgasser
- * @version 1.0
  * @created 10.02.17
  */
 public class MetadataLookupMessageHandler extends StatelessWebsocketMessageHandler<MetadataLookup> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/MetadataLookupMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/MetadataLookupMessageHandler.java
@@ -1,36 +1,40 @@
 package org.vitrivr.cineast.api.websocket.handlers;
 
+import java.util.List;
 import org.eclipse.jetty.websocket.api.Session;
-import org.vitrivr.cineast.api.websocket.handlers.abstracts.StatelessWebsocketMessageHandler;
-import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 import org.vitrivr.cineast.api.messages.lookup.MetadataLookup;
 import org.vitrivr.cineast.api.messages.result.MediaObjectMetadataQueryResult;
+import org.vitrivr.cineast.api.websocket.handlers.abstracts.StatelessWebsocketMessageHandler;
+import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 import org.vitrivr.cineast.core.db.dao.reader.MediaObjectMetadataReader;
 import org.vitrivr.cineast.standalone.config.Config;
 
-import java.util.List;
-
 /**
+ * This class extends the {@link StatelessWebsocketMessageHandler} abstract class and handles
+ * messages of type {@link MetadataLookup}.
+ *
  * @author rgasser
  * @version 1.0
  * @created 10.02.17
  */
 public class MetadataLookupMessageHandler extends StatelessWebsocketMessageHandler<MetadataLookup> {
 
-    /**
-     * Invoked when a Message of type MetadataLookup arrives and requires handling. Looks up the
-     * MultimediaMetadataDescriptors of the requested objects, wraps them in a MediaObjectMetadataQueryResult object
-     * and writes them to the stream.
-     *
-     * @param session WebSocketSession for which the message arrived.
-     * @param message Message of type a that needs to be handled.
-     */
-    @Override
-    public void handle(Session session, MetadataLookup message) {
-        Thread.currentThread().setName("metadata-lookup-handler");
-        MediaObjectMetadataReader reader = new MediaObjectMetadataReader(Config.sharedConfig().getDatabase().getSelectorSupplier().get());
-        List<MediaObjectMetadataDescriptor> descriptors = reader.lookupMultimediaMetadata(message.getIds());
-        this.write(session, new MediaObjectMetadataQueryResult("", descriptors));
-        reader.close();
-    }
+  /**
+   * Invoked when a Message of type MetadataLookup arrives and requires handling. Looks up the
+   * MultimediaMetadataDescriptors of the requested objects, wraps them in a
+   * MediaObjectMetadataQueryResult object and writes them to the stream.
+   *
+   * @param session WebSocketSession for which the message arrived.
+   * @param message Message of type a that needs to be handled.
+   */
+  @Override
+  public void handle(Session session, MetadataLookup message) {
+    Thread.currentThread().setName("metadata-lookup-handler");
+    MediaObjectMetadataReader reader = new MediaObjectMetadataReader(
+        Config.sharedConfig().getDatabase().getSelectorSupplier().get());
+    List<MediaObjectMetadataDescriptor> descriptors = reader
+        .lookupMultimediaMetadata(message.getIds());
+    this.write(session, new MediaObjectMetadataQueryResult("", descriptors));
+    reader.close();
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/StatusMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/StatusMessageHandler.java
@@ -9,7 +9,6 @@ import org.vitrivr.cineast.api.websocket.handlers.abstracts.StatelessWebsocketMe
  * messages of type {@link Ping}.
  *
  * @author rgasser
- * @version 1.0
  * @created 19.01.17
  */
 public class StatusMessageHandler extends StatelessWebsocketMessageHandler<Ping> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/StatusMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/StatusMessageHandler.java
@@ -1,18 +1,29 @@
 package org.vitrivr.cineast.api.websocket.handlers;
 
 import org.eclipse.jetty.websocket.api.Session;
-import org.vitrivr.cineast.api.websocket.handlers.abstracts.StatelessWebsocketMessageHandler;
 import org.vitrivr.cineast.api.messages.general.Ping;
+import org.vitrivr.cineast.api.websocket.handlers.abstracts.StatelessWebsocketMessageHandler;
 
 /**
+ * This class extends the {@link StatelessWebsocketMessageHandler} abstract class and handles
+ * messages of type {@link Ping}.
+ *
  * @author rgasser
  * @version 1.0
  * @created 19.01.17
  */
 public class StatusMessageHandler extends StatelessWebsocketMessageHandler<Ping> {
-    @Override
-    public void handle(Session session, Ping message) {
-       message.setStatus(Ping.StatusEnum.OK);
-       this.write(session, message);
-    }
+
+  /**
+   * Invoked when a Message of type Ping arrives and requires handling. Sets the Ping status of the
+   * message to OK and writes it back on the WebSocket.
+   *
+   * @param session WebSocketSession for which the message arrived.
+   * @param message Message of type a that needs to be handled.
+   */
+  @Override
+  public void handle(Session session, Ping message) {
+    message.setStatus(Ping.StatusEnum.OK);
+    this.write(session, message);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/AbstractWebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/AbstractWebsocketMessageHandler.java
@@ -20,7 +20,6 @@ import org.vitrivr.cineast.core.util.json.JsonWriter;
  * stream.
  *
  * @author rgasser
- * @version 1.0
  * @created 22.01.17
  */
 public abstract class AbstractWebsocketMessageHandler<A> implements WebsocketMessageHandler<A> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/AbstractWebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/AbstractWebsocketMessageHandler.java
@@ -15,7 +15,9 @@ import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
 import org.vitrivr.cineast.core.util.json.JsonWriter;
 
 /**
- * This abstract class implements the WebsocketMessageHandler interface and provides basic functionality like a convenience method to write information back to the underlying WebSocket stream.
+ * This abstract class implements the WebsocketMessageHandler interface and provides basic
+ * functionality like a convenience method to write information back to the underlying WebSocket
+ * stream.
  *
  * @author rgasser
  * @version 1.0
@@ -38,7 +40,8 @@ public abstract class AbstractWebsocketMessageHandler<A> implements WebsocketMes
     StopWatch watch = StopWatch.createStarted();
     String json = this.writer.toJson(message);
     if (message.getMessageType() != MessageType.PING) {
-      LOGGER.trace("Serialization for {} in {} ms", message.getMessageType(), watch.getTime(TimeUnit.MILLISECONDS));
+      LOGGER.trace("Serialization for {} in {} ms", message.getMessageType(),
+          watch.getTime(TimeUnit.MILLISECONDS));
     }
     String callbackName = Thread.currentThread().getName();
     CompletableFuture<Void> future = new CompletableFuture<>();
@@ -56,7 +59,8 @@ public abstract class AbstractWebsocketMessageHandler<A> implements WebsocketMes
           return;
         }
         watch.stop();
-        LOGGER.trace("{}: Successfully wrote message {} in {} ms", callbackName, message.getMessageType(), watch.getTime(TimeUnit.MILLISECONDS));
+        LOGGER.trace("{}: Successfully wrote message {} in {} ms", callbackName,
+            message.getMessageType(), watch.getTime(TimeUnit.MILLISECONDS));
       }
     });
     return future;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/StatelessWebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/StatelessWebsocketMessageHandler.java
@@ -1,22 +1,25 @@
 package org.vitrivr.cineast.api.websocket.handlers.abstracts;
 
 /**
- * This abstract class implements the WebsocketMessageHandler interface. The assumption for classes extending this class
- * is that they are statelsse. Hence, the same instance of the message handler can be used to handle messages from
- * different sessions.
+ * This abstract class implements the WebsocketMessageHandler interface.
+ *
+ * <p>The assumption for classes extending this class is that they are stateless. Hence, the same
+ * instance of the message handler can be used to handle messages from different sessions.</p>
  *
  * @author rgasser
  * @version 1.0
  * @created 19.01.17
  */
-public abstract class StatelessWebsocketMessageHandler<A> extends AbstractWebsocketMessageHandler<A> {
-    /**
-     * Indicates whether the WebsocketMessageHandler is stateless or not.
-     *
-     * @return True if WebsocketMessageHandler is stateless, false otherwise.
-     */
-    @Override
-    public final boolean isStateless() {
-        return true;
-    }
+public abstract class StatelessWebsocketMessageHandler<A> extends
+    AbstractWebsocketMessageHandler<A> {
+
+  /**
+   * Indicates whether the WebsocketMessageHandler is stateless or not.
+   *
+   * @return True if WebsocketMessageHandler is stateless, false otherwise.
+   */
+  @Override
+  public final boolean isStateless() {
+    return true;
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/StatelessWebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/abstracts/StatelessWebsocketMessageHandler.java
@@ -7,7 +7,6 @@ package org.vitrivr.cineast.api.websocket.handlers.abstracts;
  * instance of the message handler can be used to handle messages from different sessions.</p>
  *
  * @author rgasser
- * @version 1.0
  * @created 19.01.17
  */
 public abstract class StatelessWebsocketMessageHandler<A> extends

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/interfaces/WebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/interfaces/WebsocketMessageHandler.java
@@ -15,7 +15,6 @@ import org.vitrivr.cineast.api.messages.interfaces.Message;
  * source of the message.</p>
  *
  * @author rgasser
- * @version 1.0
  * @created 12.01.17
  * @see Message
  */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/interfaces/WebsocketMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/interfaces/WebsocketMessageHandler.java
@@ -4,32 +4,35 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 
 /**
- * Interface for a WebsocketMessageHandler handler that handles a message of type A (type variable).
+ * Interface for a WebsocketMessageHandler handler that handles a message of type A (type
+ * variable).
  *
- * The assumption behind this class is that another class routes incoming WebSocket messages towards the correct
- * WebsocketMessageHandler instance. That instance then carries out all the necessary steps to create an appropriate
- * response for the incoming message and sends that response to the source of the message.
- *
- * @see Message
+ * <p>The assumption behind this class is that another class routes incoming WebSocket messages
+ * towards
+ * the correct WebsocketMessageHandler instance.</p>
+ * <p>That instance then carries out all the necessary steps to create an appropriate response for
+ * the incoming message and sends that response to the
+ * source of the message.</p>
  *
  * @author rgasser
  * @version 1.0
  * @created 12.01.17
+ * @see Message
  */
-public interface WebsocketMessageHandler<A>  {
+public interface WebsocketMessageHandler<A> {
 
-    /**
-     * Invoked when a Message of type A arrives and requires handling.
-     *
-     * @param session WebSocketSession for which the message arrived.
-     * @param message Message of type a that needs to be handled.
-     */
-    void handle(Session session, A message);
+  /**
+   * Invoked when a Message of type A arrives and requires handling.
+   *
+   * @param session WebSocketSession for which the message arrived.
+   * @param message Message of type a that needs to be handled.
+   */
+  void handle(Session session, A message);
 
-    /**
-     * Indicates whether the WebsocketMessageHandler is stateless or not.
-     *
-     * @return True if WebsocketMessageHandler is stateless, false otherwise.
-     */
-    boolean isStateless();
+  /**
+   * Indicates whether the WebsocketMessageHandler is stateless or not.
+   *
+   * @return True if WebsocketMessageHandler is stateless, false otherwise.
+   */
+  boolean isStateless();
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/AbstractQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/AbstractQueryMessageHandler.java
@@ -41,6 +41,10 @@ import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.config.ConstrainedQueryConfig;
 
 /**
+ * This abstract class extends the {@link StatelessWebsocketMessageHandler} abstract class and
+ * provides various methods for the concrete implementations of message handlers to handle messages
+ * and write back to the websocket.
+ *
  * @author rgasser
  * @version 1.0
  * @created 27.04.17
@@ -119,7 +123,8 @@ public abstract class AbstractQueryMessageHandler<T extends Query> extends State
   protected abstract void execute(Session session, QueryConfig qconf, T message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception;
 
   /**
-   * Performs a lookup for the {@link MediaSegmentDescriptor} identified by the provided IDs and returns a list of the {@link MediaSegmentDescriptor}s that were found.
+   * Performs a lookup for the {@link MediaSegmentDescriptor} identified by the provided IDs and
+   * returns a list of the {@link MediaSegmentDescriptor}s that were found.
    *
    * @param segmentIds List of segment IDs that should be looked up.
    * @return List of found {@link MediaSegmentDescriptor}
@@ -132,7 +137,8 @@ public abstract class AbstractQueryMessageHandler<T extends Query> extends State
   }
 
   /**
-   * Performs a lookup for the {@link MediaObjectDescriptor} identified by the provided object IDs and returns a list of the {@link MediaSegmentDescriptor}s that were found.
+   * Performs a lookup for the {@link MediaObjectDescriptor} identified by the provided object IDs
+   * and returns a list of the {@link MediaSegmentDescriptor}s that were found.
    *
    * @param objectIds List of object IDs that should be looked up.
    * @return List of found {@link MediaObjectDescriptor}
@@ -192,7 +198,7 @@ public abstract class AbstractQueryMessageHandler<T extends Query> extends State
     List<Thread> threads = new ArrayList<>();
     segmentIds.removeAll(segmentIdsForWhichMetadataIsFetched);
     segmentIdsForWhichMetadataIsFetched.addAll(segmentIds);
-    //chunk for memory safety-purposes
+    /* Chunk for memory safety-purposes. */
     if (segmentIds.size() > 100_000) {
       return Lists.partition(segmentIds, 100_000).stream().map(list -> loadAndWriteSegmentMetadata(session, queryId, list, segmentIdsForWhichMetadataIsFetched)).flatMap(Collection::stream).collect(Collectors.toList());
     }
@@ -221,7 +227,8 @@ public abstract class AbstractQueryMessageHandler<T extends Query> extends State
   }
 
   /**
-   * Fetches and submits all the data (e.g. {@link MediaObjectDescriptor}, {@link MediaSegmentDescriptor}) to the UI. Should be executed before sending results.
+   * Fetches and submits all the data (e.g. {@link MediaObjectDescriptor}, {@link
+   * MediaSegmentDescriptor}) to the UI. Should be executed before sending results.
    *
    * @return objectIds retrieved for the segmentIds
    */
@@ -246,19 +253,37 @@ public abstract class AbstractQueryMessageHandler<T extends Query> extends State
     return objectIds;
   }
 
-  protected List<Thread> submitMetadata(Session session, String queryId, List<String> segmentIds, List<String> objectIds, Collection<String> segmentIdsForWhichMetadataIsFetched, Collection<String> objectIdsForWhichMetadataIsFetched) {
-    /* Load and transmit segment & object metadata. */
-    List<Thread> segmentThreads = this.loadAndWriteSegmentMetadata(session, queryId, segmentIds, segmentIdsForWhichMetadataIsFetched);
-    List<Thread> objectThreads = this.loadAndWriteObjectMetadata(session, queryId, objectIds, objectIdsForWhichMetadataIsFetched);
+  /**
+   * Loads and Submits all the metadata (e.g. {@link MediaSegmentMetadataDescriptor}, {@link
+   * MediaObjectMetadataQueryResult}) associated with a collection of segment IDs for which the
+   * metadata was fetched.
+   *
+   * @param session                             The {@link Session} object used to transmit the
+   *                                            results.
+   * @param queryId                             ID of the running query.
+   * @param segmentIds                          Segment IDs of the metadata results.
+   * @param objectIds                           Object IDs of the metadata result.
+   * @param segmentIdsForWhichMetadataIsFetched Segment IDs for which the metadata was fetched and
+   *                                            transferred.
+   */
+  protected List<Thread> submitMetadata(Session session, String queryId, List<String> segmentIds,
+      List<String> objectIds, Collection<String> segmentIdsForWhichMetadataIsFetched,
+      Collection<String> objectIdsForWhichMetadataIsFetched) {
+    List<Thread> segmentThreads = this.loadAndWriteSegmentMetadata(session, queryId, segmentIds,
+        segmentIdsForWhichMetadataIsFetched);
+    List<Thread> objectThreads = this.loadAndWriteObjectMetadata(session, queryId, objectIds,
+        objectIdsForWhichMetadataIsFetched);
     segmentThreads.addAll(objectThreads);
     return segmentThreads;
   }
 
   /**
-   * Fetches and submits all the data (e.g. {@link MediaObjectDescriptor}, {@link MediaSegmentDescriptor}) associated with the raw results produced by a similarity search in a specific category. q
-   *  @param session  The {@link Session} object used to transmit the results.
+   * Fetches and submits all the data (e.g. {@link MediaObjectDescriptor}, {@link MediaSegmentDescriptor}) associated with the raw results produced by a similarity search in a specific category.
+   *
+   * @param session  The {@link Session} object used to transmit the results.
    * @param queryId  ID of the running query.
    * @param category Name of the query category.
+   * @param raw      List of raw per-category results (segmentId -> score).
    * @param raw      List of raw per-category results (segmentId -> score).
    * @return
    */

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/AbstractQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/AbstractQueryMessageHandler.java
@@ -46,7 +46,6 @@ import org.vitrivr.cineast.standalone.config.ConstrainedQueryConfig;
  * and write back to the websocket.
  *
  * @author rgasser
- * @version 1.0
  * @created 27.04.17
  */
 public abstract class AbstractQueryMessageHandler<T extends Query> extends StatelessWebsocketMessageHandler<T> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/MoreLikeThisQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/MoreLikeThisQueryMessageHandler.java
@@ -18,7 +18,6 @@ import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
  * type {@link MoreLikeThisQuery}.
  *
  * @author rgasser
- * @version 1.0
  * @created 27.04.17
  */
 public class MoreLikeThisQueryMessageHandler extends

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
@@ -16,7 +16,6 @@ import org.vitrivr.cineast.api.messages.query.NeighboringSegmentQuery;
  * messages of type {@link NeighboringSegmentQuery}.
  *
  * @author rgasser
- * @version 1.0
  * @created 24.01.18
  */
 public class NeighbouringQueryMessageHandler extends

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
@@ -1,57 +1,70 @@
 package org.vitrivr.cineast.api.websocket.handlers.queries;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.eclipse.jetty.websocket.api.Session;
 import org.vitrivr.cineast.api.messages.result.MediaSegmentQueryResult;
 import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
 import org.vitrivr.cineast.api.messages.query.NeighboringSegmentQuery;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+/**
+ * This class extends the {@link AbstractQueryMessageHandler} abstract class and handles
+ * messages of type {@link NeighboringSegmentQuery}.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 24.01.18
+ */
+public class NeighbouringQueryMessageHandler extends
+    AbstractQueryMessageHandler<NeighboringSegmentQuery> {
 
-public class NeighbouringQueryMessageHandler extends AbstractQueryMessageHandler<NeighboringSegmentQuery> {
-    /**
-     * Executes a {@link NeighboringSegmentQuery} message. Performs a lookup for the {@link MediaSegmentDescriptor}s
-     * that are temporal neigbours of the provided segment ID.
-     *  @param session WebSocket session the invocation is associated with.
-     * @param qconf The {@link QueryConfig} that contains additional specifications.
-     * @param message Instance of {@link NeighboringSegmentQuery}
-     * @param segmentIdsForWhichMetadataIsFetched
-     * @param objectIdsForWhichMetadataIsFetched
-     */
-    @Override
-    public void execute(Session session, QueryConfig qconf, NeighboringSegmentQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
-        /* Prepare QueryConfig (so as to obtain a QueryId). */
-        final String uuid = qconf.getQueryId().toString();
+  /**
+   * Executes a {@link NeighboringSegmentQuery} message. Performs a lookup for the {@link
+   * MediaSegmentDescriptor}s that are temporal neigbours of the provided segment ID.
+   *
+   * @param session                             WebSocket session the invocation is associated
+   *                                            with.
+   * @param qconf                               The {@link QueryConfig} that contains additional
+   *                                            specifications.
+   * @param message                             Instance of {@link NeighboringSegmentQuery}
+   * @param segmentIdsForWhichMetadataIsFetched Segment IDs for which metadata is fetched
+   * @param objectIdsForWhichMetadataIsFetched  Object IDs for which metadata is fetched
+   */
+  @Override
+  public void execute(Session session, QueryConfig qconf, NeighboringSegmentQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
+      /* Prepare QueryConfig (so as to obtain a QueryId). */
+      final String uuid = qconf.getQueryId().toString();
 
-        /* Retrieve segments. If empty, abort query. */
-        final String segmentId = message.getSegmentId();
+      /* Retrieve segments. If empty, abort query. */
+      final String segmentId = message.getSegmentId();
 
-        if (segmentId == null || segmentId.isEmpty()){
-            return;
-        }
+      if (segmentId == null || segmentId.isEmpty()){
+          return;
+      }
 
-        Optional<MediaSegmentDescriptor> segmentOption = this.mediaSegmentReader.lookUpSegment(segmentId);
+      Optional<MediaSegmentDescriptor> segmentOption = this.mediaSegmentReader.lookUpSegment(segmentId);
 
-        if(!segmentOption.isPresent()){
-            return;
-        }
+      if(!segmentOption.isPresent()){
+          return;
+      }
 
-        MediaSegmentDescriptor segment = segmentOption.get();
+      MediaSegmentDescriptor segment = segmentOption.get();
 
-        final List<MediaSegmentDescriptor> segments = this.mediaSegmentReader.lookUpSegmentsByNumberRange(segment.getObjectId(), segment.getSequenceNumber() - message.getCount(), segment.getSequenceNumber() + message.getCount());
+      final List<MediaSegmentDescriptor> segments = this.mediaSegmentReader.lookUpSegmentsByNumberRange(segment.getObjectId(), segment.getSequenceNumber() - message.getCount(), segment.getSequenceNumber() + message.getCount());
 
-        /* Write segments to stream. */
-        CompletableFuture<Void> future = this.write(session, new MediaSegmentQueryResult(uuid, segments));
+      /* Write segments to stream. */
+      CompletableFuture<Void> future = this.write(session, new MediaSegmentQueryResult(uuid, segments));
 
-        /* Load and transmit segment metadata. */
-        List<Thread> threads = this.loadAndWriteSegmentMetadata(session, uuid, segments.stream().map(MediaSegmentDescriptor::getSegmentId).collect(Collectors.toList()), segmentIdsForWhichMetadataIsFetched);
-        for (Thread thread : threads) {
-            thread.join();
-        }
-        future.join();
-    }
+      /* Load and transmit segment metadata. */
+      List<Thread> threads = this.loadAndWriteSegmentMetadata(session, uuid, segments.stream().map(MediaSegmentDescriptor::getSegmentId).collect(
+          Collectors.toList()), segmentIdsForWhichMetadataIsFetched);
+      for (Thread thread : threads) {
+          thread.join();
+      }
+      future.join();
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
@@ -17,7 +17,6 @@ import org.vitrivr.cineast.api.messages.query.SegmentQuery;
  * type {@link SegmentQuery}.
  *
  * @author rgasser
- * @version 1.0
  * @created 28.12.18
  */
 public class SegmentQueryMessageHandler extends AbstractQueryMessageHandler<SegmentQuery> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
@@ -1,4 +1,7 @@
 package org.vitrivr.cineast.api.websocket.handlers.queries;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.jetty.websocket.api.Session;
@@ -9,23 +12,34 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
 import org.vitrivr.cineast.api.messages.query.SegmentQuery;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
+/**
+ * This class extends the {@link AbstractQueryMessageHandler} abstract class and handles messages of
+ * type {@link SegmentQuery}.
+ *
+ * @author rgasser
+ * @version 1.0
+ * @created 28.12.18
+ */
 public class SegmentQueryMessageHandler extends AbstractQueryMessageHandler<SegmentQuery> {
-    /**
-     * Executes a {@link SegmentQuery} message. Performs a lookup for the segment ID specified in the {@link SegmentQuery} object.
-     *  @param session WebSocket session the invocation is associated with.
-     * @param qconf The {@link QueryConfig} that contains additional specifications.
-     * @param message Instance of {@link SegmentQuery}
-     * @param segmentIdsForWhichMetadataIsFetched
-     * @param objectIdsForWhichMetadataIsFetched
-     */
-    @Override
-    public void execute(Session session, QueryConfig qconf, SegmentQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
-        /* Prepare QueryConfig (so as to obtain a QueryId). */
-        final String uuid = qconf.getQueryId().toString();
+
+  /**
+   * Executes a {@link SegmentQuery} message. Performs a lookup for the segment ID specified in the
+   * {@link SegmentQuery} object.
+   *
+   * @param session                             WebSocket session the invocation is associated
+   *                                            with.
+   * @param qconf                               The {@link QueryConfig} that contains additional
+   *                                            specifications.
+   * @param message                             Instance of {@link SegmentQuery}
+   * @param segmentIdsForWhichMetadataIsFetched Segment IDs for which metadata is fetched
+   * @param objectIdsForWhichMetadataIsFetched  Object IDs for which metadata is fetched
+   */
+  @Override
+  public void execute(Session session, QueryConfig qconf, SegmentQuery message,
+      Set<String> segmentIdsForWhichMetadataIsFetched,
+      Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
+    /* Prepare QueryConfig (so as to obtain a QueryId). */
+    final String uuid = qconf.getQueryId().toString();
 
         /* Retrieve segments; if empty, abort query. */
         final List<String> segmentId = new ArrayList<>(0);

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.eclipse.jetty.websocket.api.Session;
 import org.vitrivr.cineast.api.messages.result.MediaObjectQueryResult;
 import org.vitrivr.cineast.api.messages.result.MediaSegmentQueryResult;

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SimilarityQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SimilarityQueryMessageHandler.java
@@ -1,7 +1,10 @@
 package org.vitrivr.cineast.api.websocket.handlers.queries;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,11 +18,10 @@ import org.vitrivr.cineast.core.data.score.SegmentScoreElement;
 import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
+ * This class extends the {@link AbstractQueryMessageHandler} abstract class and handles messages of
+ * type {@link SimilarityQuery}.
+ *
  * @author rgasser
  * @version 1.0
  * @created 12.01.17
@@ -35,12 +37,16 @@ public class SimilarityQueryMessageHandler extends AbstractQueryMessageHandler<S
   }
 
   /**
-   * Executes a {@link SimilarityQuery}. Performs the similarity query based on the {@link QueryContainer} objects provided in the {@link SimilarityQuery}.
-   *  @param session WebSocket session the invocation is associated with.
-   * @param qconf The {@link QueryConfig} that contains additional specifications.
-   * @param message Instance of {@link SimilarityQuery}
-   * @param segmentIdsForWhichMetadataIsFetched
-   * @param objectIdsForWhichMetadataIsFetched
+   * Executes a {@link SimilarityQuery}. Performs the similarity query based on the {@link
+   * QueryContainer} objects provided in the {@link SimilarityQuery}.
+   *
+   * @param session                             WebSocket session the invocation is associated
+   *                                            with.
+   * @param qconf                               The {@link QueryConfig} that contains additional
+   *                                            specifications.
+   * @param message                             Instance of {@link SimilarityQuery}
+   * @param segmentIdsForWhichMetadataIsFetched Segment IDs for which metadata is fetched
+   * @param objectIdsForWhichMetadataIsFetched  Object IDs for which metadata is fetched
    */
   @Override
   public void execute(Session session, QueryConfig qconf, SimilarityQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SimilarityQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SimilarityQueryMessageHandler.java
@@ -23,7 +23,6 @@ import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
  * type {@link SimilarityQuery}.
  *
  * @author rgasser
- * @version 1.0
  * @created 12.01.17
  */
 public class SimilarityQueryMessageHandler extends AbstractQueryMessageHandler<SimilarityQuery> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
@@ -29,7 +29,6 @@ import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
  * type {@link TemporalQuery}.
  *
  * @author silvanheller
- * @version 1.0
  * @created 17.02.20
  */
 public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<TemporalQuery> {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
@@ -24,6 +24,14 @@ import org.vitrivr.cineast.core.data.score.SegmentScoreElement;
 import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.util.ContinuousRetrievalLogic;
 
+/**
+ * This class extends the {@link AbstractQueryMessageHandler} abstract class and handles messages of
+ * type {@link TemporalQuery}.
+ *
+ * @author silvanheller
+ * @version 1.0
+ * @created 17.02.20
+ */
 public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<TemporalQuery> {
 
   private static final Logger LOGGER = LogManager.getLogger();
@@ -34,6 +42,18 @@ public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<Tem
     this.continuousRetrievalLogic = retrievalLogic;
   }
 
+  /**
+   * Executes a {@link TemporalQuery}. Performs the staged similarity queries in temporal order
+   * based on the {@link QueryStage} objects provided in the {@link TemporalQuery}.
+   *
+   * @param session                             WebSocket session the invocation is associated
+   *                                            with.
+   * @param qconf                               The {@link QueryConfig} that contains additional
+   *                                            specifications.
+   * @param message                             Instance of {@link TemporalQuery}
+   * @param segmentIdsForWhichMetadataIsFetched Segment IDs for which metadata is fetched
+   * @param objectIdsForWhichMetadataIsFetched  Object IDs for which metadata is fetched
+   */
   @Override
   public void execute(Session session, QueryConfig qconf, TemporalQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
     StopWatch watch = StopWatch.createStarted();
@@ -119,7 +139,7 @@ public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<Tem
               LOGGER.trace("Category {} at stage {} executed @ {} ms", category, finalStageIndex, watch.getTime(TimeUnit.MILLISECONDS));
 
               /* If this is the last stage, we can send relevant results per category back to the UI.
-               * Otherwise, we cannot since we might send results to the UI which would be filtered at a later stage
+              Otherwise, we cannot since we might send results to the UI which would be filtered at a later stage
                */
               if (finalStageIndex == stagedSimilarityQuery.stages.size() - 1) {
                 /* Finalize and submit per-container results */


### PR DESCRIPTION
In order to understand the current code better and to get familiar with the developments over time, I spent some time improving maintainability by updating the documentation and enforcing a common checkstyle at various locations of the API package.

I did not alter any logic and only applied reformatting rules based on the file in the `docs/` folder.

I tried to develop a consistent docstyle over all classes from existing documentation already written.

- Enforced the current vitrivr checkstyle on various classes in the API package
- Extended and wrote additional documentation on various classes in the API package