### PR TITLE
Standardize toString in API messages

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/abstracts/AbstractQueryResultMessage.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.abstracts;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.QueryResultMessage;
 
 import java.util.List;
@@ -44,9 +46,6 @@ public abstract class AbstractQueryResultMessage<T> implements QueryResultMessag
 
   @Override
   public String toString() {
-    return "AbstractQueryResultMessage{" +
-        "content=" + content +
-        ", queryId='" + queryId + '\'' +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/AbstractMetadataFilterDescriptor.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 import java.util.Arrays;
@@ -73,5 +75,10 @@ public abstract class AbstractMetadataFilterDescriptor implements
   @JsonIgnore
   public List<String> getKeywordsAsListLowercase() {
     return getKeywords().stream().map(String::toLowerCase).collect(Collectors.toList());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataDomainFilter.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.components;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 import java.util.Arrays;
@@ -29,8 +31,6 @@ public class MetadataDomainFilter extends AbstractMetadataFilterDescriptor imple
 
   @Override
   public String toString() {
-    return "MetadataDomainFilter{" +
-            "keywords=" + Arrays.toString(keywords.toArray()) +
-            '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/components/MetadataKeyFilter.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.components;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
 
 import java.util.Arrays;
@@ -29,8 +31,6 @@ public class MetadataKeyFilter extends AbstractMetadataFilterDescriptor implemen
 
   @Override
   public String toString() {
-    return "MetadataKeyFilter{" +
-            "keywords=" + Arrays.toString(keywords.toArray()) +
-            '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/credentials/Credentials.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.credentials;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class Credentials {
 
@@ -23,7 +25,6 @@ private String username, password; //more options to come
 
   @Override
   public String toString() {
-    return String.format("Credentials [username=%s, password=%s]", username, password);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
-  
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/AnyMessage.java
@@ -1,6 +1,8 @@
 package org.vitrivr.cineast.api.messages.general;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -23,8 +25,6 @@ public class AnyMessage implements Message {
 
     @Override
     public String toString() {
-        return "AnyMessage{" +
-                "messageType=" + messageType +
-                '}';
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Error.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.general;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -49,9 +51,6 @@ public class Error implements Message {
 
     @Override
     public String toString() {
-        return "Error{" +
-                "message='" + message + '\'' +
-                ", timestamp=" + timestamp +
-                '}';
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/general/Ping.java
@@ -1,6 +1,8 @@
 package org.vitrivr.cineast.api.messages.general;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -37,8 +39,6 @@ public class Ping implements Message {
 
     @Override
     public String toString() {
-        return "Ping{" +
-                "status=" + status +
-                '}';
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/ColumnSpecification.java
@@ -34,6 +34,6 @@ public class ColumnSpecification implements Message {
 
   @Override
   public String toString() {
-    return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/IdList.java
@@ -3,6 +3,8 @@ package org.vitrivr.cineast.api.messages.lookup;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -34,8 +36,6 @@ public class IdList{
 
   @Override
   public String toString() {
-    return "IdList{" +
-        "ids=" + Arrays.toString(ids.toArray()) +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/MetadataLookup.java
@@ -53,9 +53,6 @@ public class MetadataLookup implements Message {
 
     @Override
     public String toString() {
-        return "MetadataLookup{" +
-                "objectIds=" + Arrays.toString(objectIds) +
-                ", domains=" + Arrays.toString(domains) +
-                '}';
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/OptionallyFilteredIdList.java
@@ -66,9 +66,6 @@ public class OptionallyFilteredIdList implements Message {
 
   @Override
   public String toString() {
-    return "OptionallyFilteredIdList{" +
-            "filters=" + Arrays.toString(filters.toArray()) +
-            ", ids=" + Arrays.toString(ids.toArray()) +
-            '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/SelectSpecification.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/lookup/SelectSpecification.java
@@ -35,6 +35,6 @@ public class SelectSpecification{
 
   @Override
   public String toString() {
-    return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/Query.java
@@ -28,7 +28,7 @@ public abstract class Query implements Message {
     }
 
     @Override
-    public String toString(){
-        return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryComponent.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryComponent.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.data.query.containers.QueryContainer;
@@ -114,9 +116,6 @@ public class QueryComponent {
 
   @Override
   public String toString() {
-    return "QueryComponent{" +
-        "terms=" + terms +
-        ", containerId=" + containerId +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryStage.java
@@ -21,6 +21,6 @@ public class QueryStage {
 
   @Override
   public String toString() {
-    return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/QueryTerm.java
@@ -39,7 +39,7 @@ public class QueryTerm {
 
   @Override
   public String toString() {
-    return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 
   /**

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/StagedSimilarityQuery.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.config.QueryConfig;
 
 /**
@@ -16,5 +18,10 @@ public class StagedSimilarityQuery {
       @JsonProperty(value = "config", required = false) QueryConfig config) {
     this.stages = stages;
     this.config = config;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/DistinctElementsResult.java
@@ -2,7 +2,8 @@ package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
-import org.vitrivr.cineast.core.data.tag.Tag;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DistinctElementsResult {
 
@@ -13,5 +14,10 @@ public class DistinctElementsResult {
   public DistinctElementsResult(String queryId, List<String> distinctElements) {
     this.queryId = queryId;
     this.distinctElements = distinctElements;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesAllCategoriesQueryResult.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Map;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 
 /**
@@ -27,4 +29,8 @@ public class FeaturesAllCategoriesQueryResult {
     this.elementID = elementID;
   }
 
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/FeaturesTextCategoryQueryResult.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * All features for a given category and element (i.e. segment, object). Only used for String features (e.g. OCR, ASR)
@@ -21,4 +23,8 @@ public class FeaturesTextCategoryQueryResult {
     this.elementID = elementID;
   }
 
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectMetadataQueryResult.java
@@ -1,11 +1,12 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectMetadataDescriptor;
-
-import java.util.List;
 
 public class MediaObjectMetadataQueryResult extends AbstractQueryResultMessage<MediaObjectMetadataDescriptor> {
 
@@ -17,5 +18,10 @@ public class MediaObjectMetadataQueryResult extends AbstractQueryResultMessage<M
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_METADATA_O;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaObjectQueryResult.java
@@ -1,11 +1,12 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
-
-import java.util.List;
 
 public class MediaObjectQueryResult extends AbstractQueryResultMessage<MediaObjectDescriptor> {
 
@@ -19,4 +20,8 @@ public class MediaObjectQueryResult extends AbstractQueryResultMessage<MediaObje
     return MessageType.QR_OBJECT;
   }
 
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentMetadataQueryResult.java
@@ -2,20 +2,26 @@ package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentMetadataDescriptor;
 
 public class MediaSegmentMetadataQueryResult extends AbstractQueryResultMessage<MediaSegmentMetadataDescriptor> {
 
-    @JsonCreator
-    public MediaSegmentMetadataQueryResult(String queryId, List<MediaSegmentMetadataDescriptor> content) {
-        super(queryId, MediaSegmentMetadataDescriptor.class, content);
-    }
+  @JsonCreator
+  public MediaSegmentMetadataQueryResult(String queryId, List<MediaSegmentMetadataDescriptor> content) {
+    super(queryId, MediaSegmentMetadataDescriptor.class, content);
+  }
 
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_METADATA_S;
   }
 
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/MediaSegmentQueryResult.java
@@ -1,17 +1,19 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
-
-import java.util.List;
 
 /**
  * @author rgasser
  * @created 12.01.17
  */
 public class MediaSegmentQueryResult extends AbstractQueryResultMessage<MediaSegmentDescriptor> {
+
   /**
    * @param content
    */
@@ -19,11 +21,14 @@ public class MediaSegmentQueryResult extends AbstractQueryResultMessage<MediaSeg
   public MediaSegmentQueryResult(String queryId, List<MediaSegmentDescriptor> content) {
     super(queryId, MediaSegmentDescriptor.class, content);
   }
-  
+
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_SEGMENT;
   }
-  
-  
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryEnd.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.result;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -22,8 +24,6 @@ public class QueryEnd implements Message {
 
   @Override
   public String toString() {
-    return "QueryEnd{" +
-        "queryId='" + queryId + '\'' +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryError.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.result;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -35,9 +37,6 @@ public class QueryError implements Message {
 
   @Override
   public String toString() {
-    return "QueryError{" +
-        "queryId='" + queryId + '\'' +
-        ", message='" + message + '\'' +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/QueryStart.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.api.messages.result;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 
@@ -28,8 +30,6 @@ public class QueryStart implements Message {
 
   @Override
   public String toString() {
-    return "QueryStart{" +
-        "queryId='" + queryId + '\'' +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SelectResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SelectResult.java
@@ -3,6 +3,8 @@ package org.vitrivr.cineast.api.messages.result;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class SelectResult {
 
@@ -13,4 +15,8 @@ public class SelectResult {
     this.columns = columns;
   }
 
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResult.java
@@ -1,18 +1,19 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.abstracts.AbstractQueryResultMessage;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.core.data.StringDoublePair;
-
-import java.util.List;
 
 /**
  * @author rgasser
  * @created 11.01.17
  */
 public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoublePair> {
-  
+
   private String category;
   private int containerId;
 
@@ -22,25 +23,22 @@ public class SimilarityQueryResult extends AbstractQueryResultMessage<StringDoub
     this.category = category;
     this.containerId = containerId;
   }
-  
+
   public int getContainerId() {
     return this.containerId;
   }
-  
+
   public String getCategory() {
     return category;
   }
-  
+
   @Override
   public MessageType getMessageType() {
     return MessageType.QR_SIMILARITY;
   }
-  
+
   @Override
   public String toString() {
-    return "SimilarityQueryResult{" +
-        "category='" + getCategory() + '\'' +
-        ", containerId='" + containerId + '\'' +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/SimilarityQueryResultBatch.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.StringDoublePair;
 
 public class SimilarityQueryResultBatch {
@@ -34,9 +36,6 @@ public class SimilarityQueryResultBatch {
 
   @Override
   public String toString() {
-    return "SimilarityQueryResultBatch{" +
-        "categories=" + categories +
-        ", results=" + results +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagIDsForElementQueryResult.java
@@ -1,6 +1,8 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class TagIDsForElementQueryResult {
 
@@ -14,5 +16,10 @@ public class TagIDsForElementQueryResult {
     this.queryId = queryId;
     this.tagIDs = tags;
     this.elementID = elementID;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/result/TagsQueryResult.java
@@ -1,21 +1,27 @@
 package org.vitrivr.cineast.api.messages.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.vitrivr.cineast.core.data.tag.Tag;
-
 import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.vitrivr.cineast.core.data.tag.Tag;
 
 /**
  * General-purpose result for any query that expects a list of tags as a result
  */
 public class TagsQueryResult {
-  
+
   public final String queryId;
   public final List<Tag> tags;
-  
+
   @JsonCreator
   public TagsQueryResult(String queryId, List<Tag> tags) {
     this.queryId = queryId;
     this.tags = tags;
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/ExtractionContainerMessage.java
@@ -3,10 +3,10 @@ package org.vitrivr.cineast.api.messages.session;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Arrays;
 import java.util.List;
-
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
@@ -15,36 +15,34 @@ import org.vitrivr.cineast.standalone.run.ExtractionItemContainer;
  * @author silvan on 22.01.18.
  */
 public class ExtractionContainerMessage implements Message {
-  
+
   private List<ExtractionItemContainer> items;
-  
+
   public ExtractionContainerMessage(ExtractionItemContainer[] items) {
     this.items = Arrays.asList(items);
   }
-  
+
   @JsonCreator
   public ExtractionContainerMessage(@JsonProperty("items") List<ExtractionItemContainer> items) {
     this.items = items;
   }
-  
+
   public List<ExtractionItemContainer> getItems() {
     return this.items;
   }
-  
+
   @JsonIgnore
   public ExtractionItemContainer[] getItemsAsArray() {
     return this.items.toArray(new ExtractionItemContainer[0]);
   }
-  
+
   @Override
   public MessageType getMessageType() {
     return null;
   }
-  
+
   @Override
   public String toString() {
-    return "ExtractionContainerMessage{" +
-        "items=" + Arrays.toString(items.toArray()) +
-        '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/SessionState.java
@@ -12,36 +12,32 @@ public class SessionState {
   private String id;
   private long validUntil;
   private SessionType type;
-  
+
   @JsonCreator
-  public SessionState(@JsonProperty("id")String id, @JsonProperty("validUntil")long validUntil, @JsonProperty("type")SessionType type){
+  public SessionState(@JsonProperty("id") String id, @JsonProperty("validUntil") long validUntil, @JsonProperty("type") SessionType type) {
     this.id = id;
     this.validUntil = validUntil;
     this.type = type;
   }
-  
-  public SessionState(Session session){
+
+  public SessionState(Session session) {
     this(session.getSessionId(), session.getEndTimeStamp(), session.getSessionType());
   }
-  
-  public String getSessionId(){
+
+  public String getSessionId() {
     return this.id;
   }
-  
-  public long getValidUntil(){
+
+  public long getValidUntil() {
     return this.validUntil;
   }
-  
-  public SessionType getType(){
+
+  public SessionType getType() {
     return this.type;
   }
 
   @Override
   public String toString() {
-    return "SessionState{" +
-            "id='" + id + '\'' +
-            ", validUntil=" + validUntil +
-            ", type=" + type +
-            '}';
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/session/StartSessionMessage.java
@@ -2,6 +2,8 @@ package org.vitrivr.cineast.api.messages.session;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.api.messages.credentials.Credentials;
 import org.vitrivr.cineast.api.messages.interfaces.Message;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
@@ -9,16 +11,16 @@ import org.vitrivr.cineast.api.messages.interfaces.MessageType;
 public class StartSessionMessage implements Message {
 
   private Credentials credentials;
-  
+
   @JsonCreator
-  public StartSessionMessage(@JsonProperty("credentials")Credentials credentials){
+  public StartSessionMessage(@JsonProperty("credentials") Credentials credentials) {
     this.credentials = credentials;
   }
-  
-  public Credentials getCredentials(){
+
+  public Credentials getCredentials() {
     return this.credentials;
   }
-  
+
   @Override
   public MessageType getMessageType() {
     return MessageType.SESSION_START;
@@ -26,7 +28,6 @@ public class StartSessionMessage implements Message {
 
   @Override
   public String toString() {
-    return String.format("StartSessionMessage [credentials=%s]", credentials);
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
   }
-
 }


### PR DESCRIPTION
Applied the same toString method to all API messages to have a unified form of logging:

- Applied the in #203 discussed style to all API message classes
- Some minor code refactoring (spaces and import orders)

The toString method employed was:
`return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);`