### PR TITLE
Partial implementation of IIIF Change Discovery API 1.0

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/IIIFConfig.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/IIIFConfig.java
@@ -13,6 +13,8 @@ public class IIIFConfig {
 
   @JsonProperty
   private String imageApiVersion;
+  @JsonProperty
+  private boolean keepImagesPostExtraction;
   @JsonProperty(value = "imageApiUrl")
   private String baseUrl;
   @JsonProperty
@@ -30,7 +32,7 @@ public class IIIFConfig {
   @JsonProperty
   private String manifestUrl;
   @JsonProperty
-  private boolean keepImagesPostExtraction;
+  private String orderedCollectionUrl;
 
   public String getManifestUrl() {
     return manifestUrl;
@@ -127,5 +129,13 @@ public class IIIFConfig {
 
   public void setKeepImagesPostExtraction(boolean keepImagesPostExtraction) {
     this.keepImagesPostExtraction = keepImagesPostExtraction;
+  }
+
+  public String getOrderedCollectionUrl() {
+    return orderedCollectionUrl;
+  }
+
+  public void setOrderedCollectionUrl(String orderedCollectionUrl) {
+    this.orderedCollectionUrl = orderedCollectionUrl;
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionFactory.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionFactory.java
@@ -38,25 +38,28 @@ public class OrderedCollectionFactory {
       OrderedCollectionPage orderedCollectionPage = OrderedCollectionPage.fromUrl(nextPage.getId());
       List<OrderedItem> orderedItems = orderedCollectionPage.getOrderedItems();
       for (OrderedItem orderedItem : orderedItems) {
-        ManifestFactory manifestFactory = null;
-        try {
-          manifestFactory = new ManifestFactory(orderedItem.getObject().getId());
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-        if (manifestFactory != null) {
-          String jobIdentifier = UUID.randomUUID().toString();
-          String manifestJobDirectoryString = jobDirectoryString + "/manifest_job_" + jobIdentifier;
-          Path manifestJobDirectory = Paths.get(manifestJobDirectoryString);
-          if (!Files.exists(manifestJobDirectory)) {
-            try {
-              Files.createDirectories(manifestJobDirectory);
-            } catch (IOException e) {
-              e.printStackTrace();
-            }
+        /* Only download images whose type is Create **/
+        if (orderedItem.getType().equals(OrderedCollection.TYPE_CREATE)) {
+          ManifestFactory manifestFactory = null;
+          try {
+            manifestFactory = new ManifestFactory(orderedItem.getObject().getId());
+          } catch (Exception e) {
+            e.printStackTrace();
           }
-          manifestFactory.saveMetadataJson(manifestJobDirectoryString, "metadata_" + jobIdentifier);
-          manifestFactory.saveAllCanvasImages(manifestJobDirectoryString, "image_" + jobIdentifier + "_");
+          if (manifestFactory != null) {
+            String jobIdentifier = UUID.randomUUID().toString();
+            String manifestJobDirectoryString = jobDirectoryString + "/manifest_job_" + jobIdentifier;
+            Path manifestJobDirectory = Paths.get(manifestJobDirectoryString);
+            if (!Files.exists(manifestJobDirectory)) {
+              try {
+                Files.createDirectories(manifestJobDirectory);
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            }
+            manifestFactory.saveMetadataJson(manifestJobDirectoryString, "metadata_" + jobIdentifier);
+            manifestFactory.saveAllCanvasImages(manifestJobDirectoryString, "image_" + jobIdentifier + "_");
+          }
         }
       }
       nextPage = orderedCollectionPage.getNext();

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionFactory.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionFactory.java
@@ -1,0 +1,29 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1;
+
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.vitrivr.cineast.core.iiif.discoveryapi.v1.models.OrderedCollection;
+import org.vitrivr.cineast.core.iiif.presentationapi.v2.MetadataJson;
+
+public class OrderedCollectionFactory {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+  private final OrderedCollection collection;
+
+  public OrderedCollectionFactory(String collectionUrl) throws Exception {
+    OrderedCollectionRequest collectionRequest = new OrderedCollectionRequest(collectionUrl);
+    this.collection = collectionRequest.parseOrderedCollection();
+    if (collection == null) {
+      throw new Exception("Error occurred in parsing the manifest!");
+    }
+  }
+
+  /**
+   * Save all the newly created images in the Ordered Collection Pages' manifests along with their respective {@link MetadataJson} metadata.iiif files
+   */
+  public void saveAllCreatedImages(String jobDirectoryString, String filenamePrefix){
+    //TODO
+    LOGGER.info("Ordered collection: "  + collection);
+  }
+}

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionRequest.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/OrderedCollectionRequest.java
@@ -1,0 +1,75 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.vitrivr.cineast.core.iiif.discoveryapi.v1.models.OrderedCollection;
+
+public class OrderedCollectionRequest {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+  private final String collectionJSON;
+  private final String url;
+
+  public OrderedCollectionRequest(String url) throws IOException {
+    this.url = url;
+    this.collectionJSON = fetchCollection(url);
+  }
+
+  /**
+   * @return Received Ordered Collection JSON String
+   * @throws IOException if an HTTP connection was not established successfully.
+   */
+  private String fetchCollection(String url) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestProperty("accept", "application/json");
+    InputStream responseStream = connection.getInputStream();
+    return IOUtils.toString(responseStream, StandardCharsets.UTF_8);
+  }
+
+
+  /**
+   * Parses the collection into a {@link OrderedCollection} object
+   *
+   * @return {@link OrderedCollection}
+   */
+  @Nullable
+  public OrderedCollection parseOrderedCollection() {
+    return parseOrderedCollection(this.collectionJSON);
+  }
+
+  /**
+   * This has been created as a separate function to help with unit testing.
+   *
+   * @param response The JSON response received from the server
+   * @return {@link OrderedCollection}
+   */
+  @Nullable
+  public OrderedCollection parseOrderedCollection(String response) {
+    OrderedCollection collection = null;
+    if (response == null || response.isEmpty()) {
+      response = this.collectionJSON;
+    }
+    try {
+      collection = new ObjectMapper().readValue(response, OrderedCollection.class);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return collection;
+  }
+
+  public String getCollectionJSON() {
+    return collectionJSON;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+}

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/IdTypeObject.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/IdTypeObject.java
@@ -1,0 +1,36 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class IdTypeObject {
+
+  @JsonProperty
+  private String id;
+
+  @JsonProperty
+  private String type;
+
+  public IdTypeObject() {
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @Override
+  public String toString() {
+    return "{" + "id='" + id + '\'' + ", type='" + type + '\'' + '}';
+  }
+}

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
@@ -1,0 +1,88 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class OrderedCollection {
+
+  @JsonProperty("@context")
+  private List<String> atContext;
+
+  @JsonProperty
+  private String id;
+
+  @JsonProperty
+  private String type;
+
+  @JsonProperty
+  private Long totalItems;
+
+  @JsonProperty
+  private IdTypeObject first;
+
+  @JsonProperty
+  private IdTypeObject last;
+
+  public OrderedCollection() {
+  }
+
+  public List<String> getAtContext() {
+    return atContext;
+  }
+
+  public void setAtContext(List<String> atContext) {
+    this.atContext = atContext;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Long getTotalItems() {
+    return totalItems;
+  }
+
+  public void setTotalItems(Long totalItems) {
+    this.totalItems = totalItems;
+  }
+
+  public IdTypeObject getFirst() {
+    return first;
+  }
+
+  public void setFirst(IdTypeObject first) {
+    this.first = first;
+  }
+
+  public IdTypeObject getLast() {
+    return last;
+  }
+
+  public void setLast(IdTypeObject last) {
+    this.last = last;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderedCollection{" +
+        "atContext=" + atContext +
+        ", id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", totalItems=" + totalItems +
+        ", first=" + first +
+        ", last=" + last +
+        '}';
+  }
+}

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
@@ -23,6 +23,9 @@ public class OrderedCollection {
   @JsonProperty
   private IdTypeObject last;
 
+  @JsonProperty
+  private List<IdTypeObject> partOf;
+
   public OrderedCollection() {
   }
 
@@ -74,6 +77,14 @@ public class OrderedCollection {
     this.last = last;
   }
 
+  public List<IdTypeObject> getPartOf() {
+    return partOf;
+  }
+
+  public void setPartOf(List<IdTypeObject> partOf) {
+    this.partOf = partOf;
+  }
+
   @Override
   public String toString() {
     return "OrderedCollection{" +
@@ -83,6 +94,7 @@ public class OrderedCollection {
         ", totalItems=" + totalItems +
         ", first=" + first +
         ", last=" + last +
+        ", partOf=" + partOf +
         '}';
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollection.java
@@ -5,6 +5,11 @@ import java.util.List;
 
 public class OrderedCollection {
 
+  public static String TYPE_CREATE = "Create";
+  public static String TYPE_ADD = "Add";
+  public static String TYPE_UPDATE = "Update";
+  public static String TYPE_REMOVE = "Remove";
+
   @JsonProperty("@context")
   private List<String> atContext;
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollectionPage.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedCollectionPage.java
@@ -1,0 +1,138 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class OrderedCollectionPage {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  @JsonProperty("@context")
+  private List<String> atContext;
+
+  @JsonProperty
+  private String id;
+
+  @JsonProperty
+  private String type;
+
+  @JsonProperty
+  private Long startIndex;
+
+  @JsonProperty
+  private IdTypeObject partOf;
+
+  @JsonProperty
+  private IdTypeObject prev;
+
+  @JsonProperty
+  private IdTypeObject next;
+
+  @JsonProperty
+  private List<OrderedItem> orderedItems;
+
+  public OrderedCollectionPage() {
+  }
+
+  public static OrderedCollectionPage fromUrl(String url) throws Exception {
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestProperty("accept", "application/json");
+    InputStream responseStream = connection.getInputStream();
+    String collectionPageJson = IOUtils.toString(responseStream, StandardCharsets.UTF_8);
+    OrderedCollectionPage orderedCollectionPage = null;
+    try {
+      orderedCollectionPage = new ObjectMapper().readValue(collectionPageJson, OrderedCollectionPage.class);
+    } catch (IOException e) {
+      LOGGER.error("Could not parse OrderedCollectionPage from URL: " + url);
+      e.printStackTrace();
+    }
+    return orderedCollectionPage;
+  }
+
+  public List<String> getAtContext() {
+    return atContext;
+  }
+
+  public void setAtContext(List<String> atContext) {
+    this.atContext = atContext;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Long getStartIndex() {
+    return startIndex;
+  }
+
+  public void setStartIndex(Long startIndex) {
+    this.startIndex = startIndex;
+  }
+
+  public IdTypeObject getPartOf() {
+    return partOf;
+  }
+
+  public void setPartOf(IdTypeObject partOf) {
+    this.partOf = partOf;
+  }
+
+  public IdTypeObject getPrev() {
+    return prev;
+  }
+
+  public void setPrev(IdTypeObject prev) {
+    this.prev = prev;
+  }
+
+  public IdTypeObject getNext() {
+    return next;
+  }
+
+  public void setNext(IdTypeObject next) {
+    this.next = next;
+  }
+
+  public List<OrderedItem> getOrderedItems() {
+    return orderedItems;
+  }
+
+  public void setOrderedItems(List<OrderedItem> orderedItems) {
+    this.orderedItems = orderedItems;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderedCollectionPage{" +
+        "atContext=" + atContext +
+        ", id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", startIndex=" + startIndex +
+        ", partOf=" + partOf +
+        ", prev=" + prev +
+        ", next=" + next +
+        ", orderedItems=" + orderedItems +
+        '}';
+  }
+}

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedItem.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/discoveryapi/v1/models/OrderedItem.java
@@ -1,0 +1,51 @@
+package org.vitrivr.cineast.core.iiif.discoveryapi.v1.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OrderedItem {
+
+  @JsonProperty
+  private String type;
+
+  @JsonProperty
+  private IdTypeObject object;
+
+  @JsonProperty
+  private String endTime;
+
+  public OrderedItem() {
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public IdTypeObject getObject() {
+    return object;
+  }
+
+  public void setObject(IdTypeObject object) {
+    this.object = object;
+  }
+
+  public String getEndTime() {
+    return endTime;
+  }
+
+  public void setEndTime(String endTime) {
+    this.endTime = endTime;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderedItem{" +
+        "type='" + type + '\'' +
+        ", object=" + object +
+        ", endTime='" + endTime + '\'' +
+        '}';
+  }
+}

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.config.DatabaseConfig;
 import org.vitrivr.cineast.core.iiif.IIIFConfig;
+import org.vitrivr.cineast.core.iiif.discoveryapi.v1.OrderedCollectionFactory;
 import org.vitrivr.cineast.core.iiif.imageapi.ImageFactory;
 import org.vitrivr.cineast.core.iiif.presentationapi.v2.ManifestFactory;
 import org.vitrivr.cineast.core.util.json.JacksonJsonProvider;
@@ -145,6 +146,26 @@ public class ExtractionCommand implements Runnable {
         }
         manifestFactory.saveMetadataJson(manifestJobDirectoryString, "metadata_" + jobIdentifier);
         manifestFactory.saveAllCanvasImages(manifestJobDirectoryString, "image_" + jobIdentifier + "_");
+      }
+    }
+    // Process Change Discovery API job
+    String orderedCollectionUrl = iiifConfig.getOrderedCollectionUrl();
+    if (orderedCollectionUrl != null && !orderedCollectionUrl.isEmpty()) {
+      OrderedCollectionFactory collectionFactory = null;
+      try {
+        collectionFactory = new OrderedCollectionFactory(orderedCollectionUrl);
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage());
+        e.printStackTrace();
+      }
+      if (collectionFactory != null) {
+        String jobIdentifier = UUID.randomUUID().toString();
+        String collectionJobDirectoryString = jobDirectoryString + "/ordered_collection_job_" + jobIdentifier;
+        Path collectionJobDirectory = Paths.get(collectionJobDirectoryString);
+        if (!Files.exists(collectionJobDirectory)) {
+          Files.createDirectories(collectionJobDirectory);
+        }
+        collectionFactory.saveAllCreatedImages(collectionJobDirectoryString, "image_" + jobIdentifier + "_");
       }
     }
     if (!iiifConfig.isKeepImagesPostExtraction()) {

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ExtractionCommand.java
@@ -29,7 +29,6 @@ import org.vitrivr.cineast.standalone.run.path.ExtractionContainerProviderFactor
 
 /**
  * A CLI command that can be used to start a media extraction based on an extraction definition file.
- *
  */
 @Command(name = "extract", description = "Starts a media extracting using the specified settings.")
 public class ExtractionCommand implements Runnable {
@@ -165,7 +164,13 @@ public class ExtractionCommand implements Runnable {
         if (!Files.exists(collectionJobDirectory)) {
           Files.createDirectories(collectionJobDirectory);
         }
-        collectionFactory.saveAllCreatedImages(collectionJobDirectoryString, "image_" + jobIdentifier + "_");
+        try {
+          LOGGER.info("Starting downloading of all manifest images specified in the OrderedCollection at url: " + orderedCollectionUrl);
+          collectionFactory.saveAllCreatedImages(collectionJobDirectoryString, "image_" + jobIdentifier + "_");
+        } catch (Exception e) {
+          LOGGER.error("Error occurred while downloading manifest images specified in the OrderedCollection at url: " + orderedCollectionUrl);
+          e.printStackTrace();
+        }
       }
     }
     if (!iiifConfig.isKeepImagesPostExtraction()) {

--- a/example_iiif_job.json
+++ b/example_iiif_job.json
@@ -29,6 +29,7 @@
           "format": "png"
         }
       ],
+      "manifestUrl": "https://dms-data.stanford.edu/data/manifests/Parker/bg021sq9590/manifest.json",
       "orderedCollectionUrl":  "https://haab-digital.klassik-stiftung.de/viewer/api/v1/records/changes/"
     }
   },

--- a/example_iiif_job.json
+++ b/example_iiif_job.json
@@ -29,7 +29,7 @@
           "format": "png"
         }
       ],
-      "manifestUrl": "https://dms-data.stanford.edu/data/manifests/Parker/bg021sq9590/manifest.json"
+      "orderedCollectionUrl":  "https://haab-digital.klassik-stiftung.de/viewer/api/v1/records/changes/"
     }
   },
   "extractors": [


### PR DESCRIPTION
This allows Cineast to download images from the manifests on a Discovery API change. Currently only Ordered Items with the `type` value of `Create` will be processed.

 ~~This PR is based on #217  and should be merged only once it has been merged into the codebase.~~
~~To see a diff of this PR and #217, see https://github.com/singaltanmay/cineast/pull/12/files~~