### PR TITLE
Visual-text co-embedding video extraction

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
@@ -94,22 +94,28 @@ public class VisualTextCoEmbedding extends AbstractFeatureModule {
       return;
     }
 
+    // Case: segment contains video frames
     if (!(shot.getVideoFrames().size() > 0 && shot.getVideoFrames().get(0) == VideoFrame.EMPTY_VIDEO_FRAME)) {
-      // Segment is video
       List<BufferedImage> frames = shot.getVideoFrames().stream()
           .map(frame -> frame.getImage().getBufferedImage())
           .collect(Collectors.toList());
 
       float[] embeddingArray = embedVideo(frames);
       this.persist(shot.getId(), new FloatVectorImpl(embeddingArray));
-    } else if (shot.getMostRepresentativeFrame() != VideoFrame.EMPTY_VIDEO_FRAME) {
-      // Segment is image
+
+      return;
+    }
+
+    // Case: segment contains image
+    if (shot.getMostRepresentativeFrame() != VideoFrame.EMPTY_VIDEO_FRAME) {
       BufferedImage image = shot.getMostRepresentativeFrame().getImage().getBufferedImage();
 
       if (image != null) {
         float[] embeddingArray = embedImage(image);
         this.persist(shot.getId(), new FloatVectorImpl(embeddingArray));
       }
+
+      // Insert return here if additional cases are added!
     }
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
@@ -20,6 +20,7 @@ import org.vitrivr.cineast.core.config.ReadableQueryConfig;
 import org.vitrivr.cineast.core.config.ReadableQueryConfig.Distance;
 import org.vitrivr.cineast.core.data.FloatVectorImpl;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
+import org.vitrivr.cineast.core.data.raw.images.MultiImage;
 import org.vitrivr.cineast.core.data.score.ScoreElement;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.features.abstracts.AbstractFeatureModule;
@@ -96,8 +97,8 @@ public class VisualTextCoEmbedding extends AbstractFeatureModule {
 
     // Case: segment contains video frames
     if (!(shot.getVideoFrames().size() > 0 && shot.getVideoFrames().get(0) == VideoFrame.EMPTY_VIDEO_FRAME)) {
-      List<BufferedImage> frames = shot.getVideoFrames().stream()
-          .map(frame -> frame.getImage().getBufferedImage())
+      List<MultiImage> frames = shot.getVideoFrames().stream()
+          .map(VideoFrame::getImage)
           .collect(Collectors.toList());
 
       float[] embeddingArray = embedVideo(frames);
@@ -223,10 +224,10 @@ public class VisualTextCoEmbedding extends AbstractFeatureModule {
     }
   }
 
-  private float[] embedVideo(List<BufferedImage> frames) {
+  private float[] embedVideo(List<MultiImage> frames) {
     initializeVisualEmbedding();
 
-    List<float[]> encodings = frames.stream().map(this::encodeImage).collect(Collectors.toList());
+    List<float[]> encodings = frames.stream().map(image -> encodeImage(image.getBufferedImage())).collect(Collectors.toList());
 
     // Sum
     float[] meanEncoding = encodings.stream().reduce(new float[ENCODING_SIZE], (encoding0, encoding1) -> {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/MotionHistogramCalculator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/MotionHistogramCalculator.java
@@ -88,8 +88,8 @@ public abstract class MotionHistogramCalculator implements Retriever {
     for (int i = 0; i < sums.length; ++i) {
       float[] hist = hists[i];
       double sum = 0;
-      for (int j = 0; j < hist.length; ++j) {
-        sum += hist[j];
+      for (float v : hist) {
+        sum += v;
       }
       if (sum > 0) {
         for (int j = 0; j < hist.length; ++j) {
@@ -100,22 +100,22 @@ public abstract class MotionHistogramCalculator implements Retriever {
       sums[i] = sum;
     }
 
-    ArrayList<Double> sumList = new ArrayList<Double>(sums.length);
+    ArrayList<Double> sumList = new ArrayList<>(sums.length);
     for (double d : sums) {
       sumList.add(d);
     }
 
-    ArrayList<ArrayList<Float>> histList = new ArrayList<ArrayList<Float>>(
+    ArrayList<ArrayList<Float>> histList = new ArrayList<>(
         hists.length);
     for (float[] hist : hists) {
-      ArrayList<Float> h = new ArrayList<Float>(8);
+      ArrayList<Float> h = new ArrayList<>(8);
       for (float f : hist) {
         h.add(f);
       }
       histList.add(h);
     }
 
-    return new Pair<List<Double>, ArrayList<ArrayList<Float>>>(sumList,
+    return new Pair<>(sumList,
         histList);
   }
 


### PR DESCRIPTION
Implemented the extraction of the visual-text co-embedding feature for videos, such that not only the most representative frame for each shot is considered, but all frames mean-pooled in the encoding space.

Additional minor cleanup refactoring in the MotionHistogramCalculator.