### PR TITLE
Fix Java build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.6.3'
+    version = '3.6.4'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/providers/primitive/PrimitiveProviderComparator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/providers/primitive/PrimitiveProviderComparator.java
@@ -30,6 +30,6 @@ public class PrimitiveProviderComparator implements Comparator<PrimitiveTypeProv
       return 1;
     }
 
-    return Comparator.<Comparable>naturalOrder().compare((Comparable) PrimitiveTypeProvider.getObject(o1), (Comparable) PrimitiveTypeProvider.getObject(o2));
+    return Comparator.<Comparable>naturalOrder().compare((Comparable<?>) PrimitiveTypeProvider.getObject(o1), (Comparable<?>) PrimitiveTypeProvider.getObject(o2));
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/providers/primitive/PrimitiveProviderComparator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/providers/primitive/PrimitiveProviderComparator.java
@@ -30,6 +30,22 @@ public class PrimitiveProviderComparator implements Comparator<PrimitiveTypeProv
       return 1;
     }
 
-    return Comparator.<Comparable>naturalOrder().compare((Comparable<?>) PrimitiveTypeProvider.getObject(o1), (Comparable<?>) PrimitiveTypeProvider.getObject(o2));
+    if (o1.getType() != o2.getType()) {
+      return 0;
+    }
+
+    switch (o1.getType()) {
+      case BOOLEAN: return Boolean.compare(o1.getBoolean(), o2.getBoolean());
+      case BYTE: return Byte.compare(o1.getByte(), o2.getByte());
+      case SHORT: return Short.compare(o1.getShort(), o2.getShort());
+      case INT: return Integer.compare(o1.getInt(), o2.getInt());
+      case FLOAT: return Float.compare(o1.getFloat(), o2.getFloat());
+      case LONG: return Long.compare(o1.getLong(), o2.getLong());
+      case DOUBLE: return Double.compare(o1.getDouble(), o2.getDouble());
+      case BITSET: return Integer.compare(o1.getBitSet().cardinality(), o2.getBitSet().cardinality());
+    }
+
+    return 0;
+
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageApiVersion.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageApiVersion.java
@@ -93,6 +93,11 @@ public class ImageApiVersion {
     }
   }
 
+  @Override
+  public int hashCode() {
+    return toNumericString().hashCode();
+  }
+
   public IMAGE_API_VERSION getVersion() {
     return this.version;
   }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageFactory.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageFactory.java
@@ -76,9 +76,9 @@ public class ImageFactory {
     }
 
     if (iiifConfig != null) {
-      if (imageApiVersion.equals(new ImageApiVersion(IMAGE_API_VERSION.TWO_POINT_ONE_POINT_ONE))) {
+      if (imageApiVersion.getVersion() == IMAGE_API_VERSION.TWO_POINT_ONE_POINT_ONE) {
         new ApiJob_v2(iiifConfig).run(jobDirectoryString, itemPrefixString);
-      } else if (imageApiVersion.equals(new ImageApiVersion(IMAGE_API_VERSION.THREE_POINT_ZERO))) {
+      } else if (imageApiVersion.getVersion() == IMAGE_API_VERSION.THREE_POINT_ZERO) {
         new ApiJob_v3(iiifConfig).run(jobDirectoryString, itemPrefixString);
       }
     } else if (canvas != null) {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageInformation.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/imageapi/ImageInformation.java
@@ -106,6 +106,11 @@ public interface ImageInformation {
       return Objects.equals(this$height, other$height);
     }
 
+    @Override
+    public int hashCode() {
+      return toString().hashCode();
+    }
+
     protected boolean canEqual(final Object other) {
       return other instanceof ImageInformation.SizesItem;
     }
@@ -171,6 +176,11 @@ public interface ImageInformation {
       final Object this$scaleFactors = this.getScaleFactors();
       final Object other$scaleFactors = other.getScaleFactors();
       return Objects.equals(this$scaleFactors, other$scaleFactors);
+    }
+
+    @Override
+    public int hashCode() {
+      return toString().hashCode();
     }
 
     protected boolean canEqual(final Object other) {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Manifest.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Manifest.java
@@ -3,6 +3,7 @@ package org.vitrivr.cineast.core.iiif.presentationapi.v2.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.vitrivr.cineast.core.data.Pair;
 
 /**
@@ -83,8 +84,9 @@ public class Manifest {
    * Custom getter for getLabel that converts List<Object> into a Pair<String, List<LabelItem>>
    */
   public Pair<String, List<LabelItem>> getLabel() {
-    if (this.label instanceof List) {
-      return new Pair<>(null, (List<LabelItem>) this.label);
+    if (this.label instanceof List<?>) {
+      var list = ((List<?>) this.label).stream().filter(item -> item instanceof LabelItem).map(item -> (LabelItem) item).collect(Collectors.toList());
+      return new Pair<>(null, list);
     } else if (this.label instanceof String) {
       return new Pair<>(((String) this.label), null);
     }
@@ -195,8 +197,9 @@ public class Manifest {
    * Custom getter for getRendering that converts List<Object> into a Pair<String, List<Rendering>>
    */
   public Pair<String, List<Rendering>> getRendering() {
-    if (this.rendering instanceof List) {
-      return new Pair<>(null, (List<Rendering>) this.rendering);
+    if (this.rendering instanceof List<?>) {
+      var list = ((List<?>) this.rendering).stream().filter(item -> item instanceof Rendering).map(item -> (Rendering) item).collect(Collectors.toList());
+      return new Pair<>(null, list);
     } else if (this.rendering instanceof String) {
       return new Pair<>(((String) this.rendering), null);
     }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Metadata.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Metadata.java
@@ -3,6 +3,7 @@ package org.vitrivr.cineast.core.iiif.presentationapi.v2.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.vitrivr.cineast.core.data.Pair;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -28,8 +29,9 @@ public class Metadata {
    * Custom getter for getLabel that converts List<Object> into a Pair<String, List<LabelItem>>
    */
   public Pair<String, List<LabelItem>> getLabel() {
-    if (this.label instanceof List) {
-      return new Pair<>(null, (List<LabelItem>) this.label);
+    if (this.label instanceof List<?>) {
+      var list = ((List<?>) this.label).stream().filter(item -> item instanceof LabelItem).map(item -> (LabelItem) item).collect(Collectors.toList());
+      return new Pair<>(null, list);
     } else if (this.label instanceof String) {
       return new Pair<>(((String) this.label), null);
     }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Structure.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/iiif/presentationapi/v2/models/Structure.java
@@ -3,6 +3,7 @@ package org.vitrivr.cineast.core.iiif.presentationapi.v2.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.vitrivr.cineast.core.data.Pair;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -51,8 +52,9 @@ class Structure {
    * Custom getter for getLabel that converts List<Object> into a Pair<String, List<LabelItem>>
    */
   public Pair<String, List<LabelItem>> getLabel() {
-    if (this.label instanceof List) {
-      return new Pair<>(null, (List<LabelItem>) this.label);
+    if (this.label instanceof List<?>) {
+      var list = ((List<?>) this.label).stream().filter(item -> item instanceof LabelItem).map(item -> (LabelItem) item).collect(Collectors.toList());
+      return new Pair<>(null, list);
     } else if (this.label instanceof String) {
       return new Pair<>(((String) this.label), null);
     }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/util/MultiTracker.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/util/MultiTracker.java
@@ -15,8 +15,7 @@ public class MultiTracker {
 
   public enum TRACKER_TYPE {CIRCULANT, TLD}
 
-  ;
-  List<TrackerObjectQuad> trackers;
+  List<TrackerObjectQuad<GrayU8>> trackers;
   List<Quadrilateral_F64> coordinates;
   GrayU8 initialFrame;
 
@@ -29,8 +28,8 @@ public class MultiTracker {
     this.trackers = new ArrayList<>();
     this.coordinates = new ArrayList<>();
     this.initialFrame = frame;
-    for (int i = 0; i < coordinates.size(); i++) {
-      this.add(coordinates.get(i), type);
+    for (Quadrilateral_F64 coordinate : coordinates) {
+      this.add(coordinate, type);
     }
   }
 
@@ -39,7 +38,7 @@ public class MultiTracker {
    * @param type       Type of the tracker
    */
   public void add(Quadrilateral_F64 coordinate, TRACKER_TYPE type) {
-    TrackerObjectQuad tracker = null;
+    TrackerObjectQuad<GrayU8> tracker;
     if (type == TRACKER_TYPE.TLD) {
       tracker = FactoryTrackerObjectQuad.tld(null, GrayU8.class);
     } else if (type == TRACKER_TYPE.CIRCULANT) {
@@ -62,7 +61,6 @@ public class MultiTracker {
     List<Pair<Boolean, Quadrilateral_F64>> result = new ArrayList<>();
     for (int i = 0; i < trackers.size(); i++) {
       Quadrilateral_F64 new_coord = this.coordinates.get(i).copy();
-      @SuppressWarnings("unchecked")
       boolean found = this.trackers.get(i).process(frame, new_coord);
       if (new_coord.getA().x < 0) {
         new_coord.getA().x = 0;

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/util/json/JacksonJsonProvider.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/util/json/JacksonJsonProvider.java
@@ -3,6 +3,7 @@ package org.vitrivr.cineast.core.util.json;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,7 +44,7 @@ public class JacksonJsonProvider implements JsonReader, JsonWriter {
     MAPPER.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
     MAPPER.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
     MAPPER.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
-    MAPPER.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS, true);
+    MAPPER.enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS.mappedFeature());
   }
 
   @Override


### PR DESCRIPTION
Fixes all but two of the Java build warnings to make it easier to see if code changes produce new build warnings.

The remaining two build warnings could not be resolved because they either require a change in an external library (Cottontail DB Client) or are unclear in the intent of the original code.