### PR TITLE
Returning no Metadata if Metadata Spec is Empty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.8.2'
+    version = '3.8.3'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -29,6 +29,9 @@ public class TemporalQuery extends Query {
    */
   private final Float maxLength;
 
+  /**
+   * Provide an empty list to fetch no metadata at all. If the field is not filled (i.e. null), all metadata is provided for backwards-compatibility
+   */
   private final List<MetadataAccessSpecification> metadataAccessSpec;
 
   @JsonCreator

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/MetadataAccessSpecification.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/MetadataAccessSpecification.java
@@ -3,7 +3,7 @@ package org.vitrivr.cineast.core.db.dao;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Use '*' in either domain or key to retrieve simply all information
+ * Use '*' in either domain or key to retrieve simply all information. In general, if an empty specification list is provided, no metadata is returned.
  */
 public class MetadataAccessSpecification {
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
@@ -60,6 +60,10 @@ public abstract class AbstractMetadataReader<R> extends AbstractEntityReader {
       LOGGER.warn("provided id-list {} or spec {} is null, returning empty list", ids, spec);
       return new ArrayList<>();
     }
+    if (spec.size() == 0) {
+      LOGGER.trace("Not returning any metadata since spec was an empty list.");
+      return new ArrayList<>();
+    }
     StopWatch watch = StopWatch.createStarted();
     ids = sanitizeIds(ids);
     spec = sanitizeSpec(spec);
@@ -69,6 +73,14 @@ public abstract class AbstractMetadataReader<R> extends AbstractEntityReader {
   }
 
   public List<R> findBySpec(List<MetadataAccessSpecification> spec) {
+    if (spec == null) {
+      LOGGER.warn("Provided spec is null, returning empty list");
+      return new ArrayList<>();
+    }
+    if (spec.size() == 0) {
+      LOGGER.trace("Not returning any metadata since spec was an empty list.");
+      return new ArrayList<>();
+    }
     StopWatch watch = StopWatch.createStarted();
     spec = sanitizeSpec(spec);
     List<Map<String, PrimitiveTypeProvider>> results = selector.getMetadataBySpec(spec);


### PR DESCRIPTION
To be backward-compatible, the implementation of the `MetadataAccessSpecification` returned all metadata if the field was not set in a query. However, the intention (and what this PR fixes) was that if an empty List is provided, no metadata is returned. This saves execution time for queries which do not care about metadata.