### PR TITLE
Temporal Query Config

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -2,11 +2,8 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
-import kotlin.collections.ArrayDeque;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.db.dao.MetadataAccessSpecification;
 
 /**
@@ -19,30 +16,16 @@ public class TemporalQuery extends Query {
    */
   private final List<StagedSimilarityQuery> queries;
 
-  /**
-   * List of time distances as floats that can be part of this {@link TemporalQuery}.
-   */
-  private final List<Float> timeDistances;
-
-  /**
-   * The max length of the temporal sequences as float that can be part of this {@link TemporalQuery}.
-   */
-  private final Float maxLength;
-
   private final List<MetadataAccessSpecification> metadataAccessSpec;
 
   @JsonCreator
   public TemporalQuery(
       @JsonProperty(value = "queries", required = true) List<StagedSimilarityQuery> queries,
-      @JsonProperty(value = "config", required = false) QueryConfig config,
-      @JsonProperty(value = "timeDistances", required = false) List<Float> timeDistances,
-      @JsonProperty(value = "maxLength", required = false) Float maxLength,
+      @JsonProperty(value = "config", required = false) TemporalQueryConfig config,
       @JsonProperty(value = "metadataAccessSpec", required = false) List<MetadataAccessSpecification> metadataAccessSpec
   ) {
     super(config);
     this.queries = queries;
-    this.timeDistances = timeDistances == null ? new ArrayList<>() : timeDistances;
-    this.maxLength = maxLength == null ? Float.MAX_VALUE : maxLength;
     this.metadataAccessSpec = metadataAccessSpec;
   }
 
@@ -61,7 +44,7 @@ public class TemporalQuery extends Query {
    * @return List<Float>
    */
   public List<Float> getTimeDistances() {
-    return timeDistances;
+    return getTemporalQueryConfig().timeDistances;
   }
 
   /**
@@ -70,7 +53,11 @@ public class TemporalQuery extends Query {
    * @return Float
    */
   public Float getMaxLength() {
-    return maxLength;
+    return getTemporalQueryConfig().maxLength;
+  }
+
+  public TemporalQueryConfig getTemporalQueryConfig() {
+    return (TemporalQueryConfig) this.config;
   }
 
   public List<MetadataAccessSpecification> getMetadataAccessSpec() {

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQuery.java
@@ -2,11 +2,8 @@ package org.vitrivr.cineast.api.messages.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
-import kotlin.collections.ArrayDeque;
 import org.vitrivr.cineast.api.messages.interfaces.MessageType;
-import org.vitrivr.cineast.core.config.QueryConfig;
 import org.vitrivr.cineast.core.db.dao.MetadataAccessSpecification;
 
 /**

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
@@ -29,6 +29,6 @@ public class TemporalQueryConfig extends QueryConfig {
     super(queryId, hints);
     this.timeDistances = timeDistances == null ? new ArrayList<>() : timeDistances;
     this.maxLength = maxLength == null ? Float.MAX_VALUE : maxLength;
-    this.computeTemporalObjects = computeTemporalObjects == null ? true : computeTemporalObjects;
+    this.computeTemporalObjects = computeTemporalObjects == null || computeTemporalObjects;
   }
 }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
@@ -17,6 +17,9 @@ public class TemporalQueryConfig extends QueryConfig {
    */
   public final Float maxLength;
 
+  /**
+   * If set explicitly to false, there will be no temporal aggregation for the temporal queries. This is mainly done for testing or evaluation purposes.
+   */
   public final boolean computeTemporalObjects;
 
 

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/messages/query/TemporalQueryConfig.java
@@ -1,0 +1,34 @@
+package org.vitrivr.cineast.api.messages.query;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.vitrivr.cineast.core.config.QueryConfig;
+
+public class TemporalQueryConfig extends QueryConfig {
+
+  /**
+   * List of time distances as floats that can be part of this {@link TemporalQuery}.
+   */
+  public final List<Float> timeDistances;
+
+  /**
+   * The max length of the temporal sequences as float that can be part of this {@link TemporalQuery}.
+   */
+  public final Float maxLength;
+
+  public final boolean computeTemporalObjects;
+
+
+  public TemporalQueryConfig(@JsonProperty(value = "queryId", required = false) String queryId,
+      @JsonProperty(value = "hints", required = false) List<Hints> hints,
+      @JsonProperty(value = "timeDistances", required = false) List<Float> timeDistances,
+      @JsonProperty(value = "maxLength", required = false) Float maxLength,
+      @JsonProperty(value = "computeTemporalObjects", required = false) Boolean computeTemporalObjects
+  ) {
+    super(queryId, hints);
+    this.timeDistances = timeDistances == null ? new ArrayList<>() : timeDistances;
+    this.maxLength = maxLength == null ? Float.MAX_VALUE : maxLength;
+    this.computeTemporalObjects = computeTemporalObjects == null ? true : computeTemporalObjects;
+  }
+}

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
@@ -212,6 +212,13 @@ public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<Tem
       ssqThread.join();
     }
 
+    /* You can skip the computation of temporal objects in the config if you wish simply to execute all queries independently (e.g. for evaluation)*/
+    if (!message.getTemporalQueryConfig().computeTemporalObjects) {
+      LOGGER.debug("Not computing temporal objects due to query config");
+      finish(metadataRetrievalThreads, cleanupThreads);
+      return;
+    }
+
     LOGGER.debug("Starting fusion for temporal context");
     long start = System.currentTimeMillis();
     /* Retrieve the MediaSegmentDescriptors needed for the temporal scoring retrieval */
@@ -256,6 +263,10 @@ public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<Tem
       futures.forEach(CompletableFuture::join);
     }
 
+    finish(metadataRetrievalThreads, cleanupThreads);
+  }
+
+  private void finish(List<Thread> metadataRetrievalThreads, List<Thread> cleanupThreads) throws InterruptedException {
     for (Thread cleanupThread : cleanupThreads) {
       cleanupThread.join();
     }


### PR DESCRIPTION
Outsourcing config values only relevant for temporal queries into a separate config. Corresponding PR for vitrivr-ng: https://github.com/vitrivr/vitrivr-ng/pull/117