### PR TITLE
Fixing NearestNeighborRows only returning id column

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.8.3'
+    version = '3.8.4'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
@@ -79,6 +79,9 @@ public interface DBSelector extends Closeable {
   <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors,
       String column, Class<T> distanceElementClass, List<ReadableQueryConfig> configs);
 
+  /**
+   * In contrast to {@link #getNearestNeighboursGeneric(int, float[], String, Class, ReadableQueryConfig)}, this method returns all elements of a row
+   */
   List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector,
       String column, ReadableQueryConfig config);
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
@@ -85,7 +85,7 @@ public final class CottontailSelector implements DBSelector {
 
   @Override
   public List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig config) {
-    final Query query = knn(k, vector, column, config);
+    final Query query = knn(k, vector, column, config, "*");
     try {
       return processResults(this.cottontail.client.query(query));
     } catch (StatusRuntimeException e) {
@@ -314,7 +314,7 @@ public final class CottontailSelector implements DBSelector {
   }
 
   public Map<String, Integer> countDistinctValues(String column) {
-    final Query query = new Query(this.fqn).select("*", null);
+    final Query query = new Query(this.fqn).select(column, null);
     final Map<String, Integer> count = new HashMap<>();
     try {
       final TupleIterator results = this.cottontail.client.query(query);
@@ -375,13 +375,31 @@ public final class CottontailSelector implements DBSelector {
    * @return {@link Query}
    */
   private Query knn(int k, float[] vector, String column, ReadableQueryConfig config) {
+    return knn(k, vector, column, config, GENERIC_ID_COLUMN_QUALIFIER);
+  }
+
+  /**
+   * Creates and returns a basic {@link Query} object for the given kNN parameters.
+   *
+   * @param k      The k parameter used for kNN
+   * @param vector The query vector (= float array).
+   * @param column The name of the column that should be queried.
+   * @param config The {@link ReadableQueryConfig} with additional parameters.
+   * @param select which rows should be selected
+   * @return {@link Query}
+   */
+  private Query knn(int k, float[] vector, String column, ReadableQueryConfig config, String... select) {
     final Set<String> relevant = config.getRelevantSegmentIds();
     final Distances distance = toDistance(config.getDistance().orElse(Distance.manhattan));
     final Query query = new Query(this.fqn)
-        .select(GENERIC_ID_COLUMN_QUALIFIER, null)
         .distance(column, vector, distance, DB_DISTANCE_VALUE_QUALIFIER)
         .order(DB_DISTANCE_VALUE_QUALIFIER, Direction.ASC)
         .limit(k);
+
+    for (String s : select) {
+      query.select(s, null);
+    }
+
 
     /* Add relevant segments (optional). */
     if (!relevant.isEmpty()) {


### PR DESCRIPTION
The `DBSelector` Interface had two abstractions for nearest-neighbor search, one of which only returns ids & distances, the other one returns the full row. The second one is used e.g by the `AverageColorRaster` Feature which has the schema `id`, `hist`, `raster` and requires the raster for score-computation. 

This PR fixes the cottontail implementation to avoid NPEs in `AverageColorRaster`. Thanks to @benzvera for pointing out the bug.
It also optimizes the `countDistinctValues` command, which only needs to retrieve the column for which it counts distinct values.