### PR TITLE
improving robustness when feature entity is missing

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
@@ -267,7 +267,7 @@ public class QueryUtil {
       return _return;
     } catch (Exception e) {
       LOGGER.error("Exception while looking up tags", e);
-      return new ArrayList<>();
+      return _return;
     }
   }
 

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
@@ -261,10 +261,14 @@ public class QueryUtil {
     List<String> _return = new ArrayList<>();
     DBSelector selector = Config.sharedConfig().getDatabase().getSelectorSupplier().get();
     selector.open(SegmentTags.SEGMENT_TAGS_TABLE_NAME);
-    List<Map<String, PrimitiveTypeProvider>> rows = selector.getRows(GENERIC_ID_COLUMN_QUALIFIER, ids);
-
-    rows.forEach(row -> _return.add(row.get(SegmentTags.TAG_ID_QUALIFIER).getString()));
-    return _return;
+    try {
+      List<Map<String, PrimitiveTypeProvider>> rows = selector.getRows(GENERIC_ID_COLUMN_QUALIFIER, ids);
+      rows.forEach(row -> _return.add(row.get(SegmentTags.TAG_ID_QUALIFIER).getString()));
+      return _return;
+    } catch (Exception e) {
+      LOGGER.error("Exception while looking up tags", e);
+      return new ArrayList<>();
+    }
   }
 
   /**


### PR DESCRIPTION
In rare cases, the `segmenttags` entity is not available when an API request is made. In this case, Cineast after this PR simply returns an empty String instead of failing the entire request.