### PR TITLE
Fixing how QueryConfig and QueryIDs are used

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/grpc/CineastQueryService.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/grpc/CineastQueryService.java
@@ -104,7 +104,7 @@ public class CineastQueryService extends CineastQueryGrpc.CineastQueryImplBase {
 
           if (lastStage) {
             responseObserver.onNext(QueryContainerUtil.similarityQueryResult(
-                term.getQueryConfig().getQueryId().toString(),
+                term.getQueryConfig().getQueryId(),
                 category,
                 results
             ));
@@ -141,7 +141,7 @@ public class CineastQueryService extends CineastQueryGrpc.CineastQueryImplBase {
     QueryConfig qconf = new QueryConfig(rqconf);
 
     /* Prepare QueryConfig (so as to obtain a QueryId). */
-    final String uuid = qconf.getQueryId().toString();
+    final String uuid = qconf.getQueryId();
     final int max = qconf.getMaxResults().orElse(Config.sharedConfig().getRetriever().getMaxResults());
     qconf.setMaxResults(max);
     final int resultsPerModule = qconf.getRawResultsPerModule() == -1 ? Config.sharedConfig().getRetriever().getMaxResultsPerModule() : qconf.getResultsPerModule();
@@ -226,7 +226,7 @@ public class CineastQueryService extends CineastQueryGrpc.CineastQueryImplBase {
                 responseObserver.onNext(
                     QueryContainerUtil.queryResult(
                         QueryContainerUtil.similarityQueryResult(
-                            qt.getQueryConfig().getQueryId().toString(),
+                            qt.getQueryConfig().getQueryId(),
                             category,
                             results
                         )));

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarPostHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarPostHandler.java
@@ -25,7 +25,7 @@ public class FindSegmentSimilarPostHandler implements ParsingPostRestHandler<Sim
 
     var returnMap = QueryUtil.findSegmentsSimilar(continuousRetrievalLogic, query.getTerms(), config);
 
-    return new SimilarityQueryResultBatch(returnMap, config.getQueryId().toString());
+    return new SimilarityQueryResultBatch(returnMap, config.getQueryId());
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarStagedPostHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarStagedPostHandler.java
@@ -39,7 +39,7 @@ public class FindSegmentSimilarStagedPostHandler implements ParsingPostRestHandl
 
     var results = QueryUtil.findSegmentsSimilarStaged(continuousRetrievalLogic, query.getStages(), config);
 
-    return new SimilarityQueryResultBatch(results, config.getQueryId().toString());
+    return new SimilarityQueryResultBatch(results, config.getQueryId());
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarTemporalPostHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/segment/FindSegmentSimilarTemporalPostHandler.java
@@ -39,7 +39,7 @@ public class FindSegmentSimilarTemporalPostHandler implements ParsingPostRestHan
 
     var temporalResults = QueryUtil.findSegmentsSimilarTemporal(continuousRetrievalLogic, query, config);
 
-    return new TemporalQueryResult(config.getQueryId().toString(), temporalResults);
+    return new TemporalQueryResult(config.getQueryId(), temporalResults);
   }
 
   @Override

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/util/QueryUtil.java
@@ -124,7 +124,7 @@ public class QueryUtil {
         )
     ).distinct().collect(Collectors.toList());
 
-    var segmentDescriptors = segmentReader.lookUpSegments(segmentIds, config.getQueryId().toString());
+    var segmentDescriptors = segmentReader.lookUpSegments(segmentIds, config.getQueryId());
     var stagedQueryResults = stagedResults.stream().map(
         resultsMap -> resultsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList())
     ).collect(Collectors.toList());

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/MoreLikeThisQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/MoreLikeThisQueryMessageHandler.java
@@ -34,7 +34,7 @@ public class MoreLikeThisQueryMessageHandler extends AbstractQueryMessageHandler
   @Override
   public void execute(Session session, QueryConfig qconf, MoreLikeThisQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
     /* Extract categories from MoreLikeThisQuery. */
-    final String queryId = qconf.getQueryId().toString();
+    final String queryId = qconf.getQueryId();
     final HashSet<String> categoryMap = new HashSet<>(message.getCategories());
 
     List<Thread> threads = new ArrayList<>();

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/NeighbouringQueryMessageHandler.java
@@ -28,7 +28,7 @@ public class NeighbouringQueryMessageHandler extends AbstractQueryMessageHandler
   @Override
   public void execute(Session session, QueryConfig qconf, NeighboringSegmentQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
     /* Prepare QueryConfig (so as to obtain a QueryId). */
-    final String uuid = qconf.getQueryId().toString();
+    final String uuid = qconf.getQueryId();
 
     /* Retrieve segments. If empty, abort query. */
     final String segmentId = message.getSegmentId();

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/SegmentQueryMessageHandler.java
@@ -30,7 +30,7 @@ public class SegmentQueryMessageHandler extends AbstractQueryMessageHandler<Segm
   @Override
   public void execute(Session session, QueryConfig qconf, SegmentQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
     /* Prepare QueryConfig (so as to obtain a QueryId). */
-    final String uuid = qconf.getQueryId().toString();
+    final String uuid = qconf.getQueryId();
 
     /* Retrieve segments; if empty, abort query. */
     final List<String> segmentId = new ArrayList<>(0);

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/websocket/handlers/queries/TemporalQueryMessageHandler.java
@@ -40,7 +40,7 @@ public class TemporalQueryMessageHandler extends AbstractQueryMessageHandler<Tem
   public void execute(Session session, QueryConfig qconf, TemporalQuery message, Set<String> segmentIdsForWhichMetadataIsFetched, Set<String> objectIdsForWhichMetadataIsFetched) throws Exception {
 
     /* Prepare the query config and get the QueryId */
-    final String uuid = qconf.getQueryId().toString();
+    final String uuid = qconf.getQueryId();
     String qid = uuid.substring(0, 3);
     final int max = Math.min(qconf.getMaxResults().orElse(Config.sharedConfig().getRetriever().getMaxResults()), Config.sharedConfig().getRetriever().getMaxResults());
     qconf.setMaxResults(max);

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/config/QueryConfig.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/config/QueryConfig.java
@@ -29,7 +29,7 @@ public class QueryConfig extends ReadableQueryConfig {
   }
 
   private QueryConfig(ReadableQueryConfig qc, UUID uuid) {
-    super(qc, uuid);
+    super(qc, uuid.toString());
   }
 
   public QueryConfig setDistanceWeights(float[] weights) {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/config/ReadableQueryConfig.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/config/ReadableQueryConfig.java
@@ -30,7 +30,7 @@ public class ReadableQueryConfig {
     lsh, ecp, mi, pq, sh, va, vaf, vav, sequential, empirical
   }
 
-  private final UUID queryId;
+  private final String queryId;
   protected Distance distance = null;
   protected float[] distanceWeights = null;
   protected float norm = Float.NaN;
@@ -50,13 +50,7 @@ public class ReadableQueryConfig {
   public ReadableQueryConfig(@JsonProperty(value = "queryId", required = false) String queryId,
       @JsonProperty(value = "hints", required = false) List<Hints> hints) {
 
-    UUID uuid = null;
-    try {
-      uuid = UUID.fromString(queryId);
-    } catch (IllegalArgumentException | NullPointerException e) {
-      uuid = UUID.randomUUID();
-    }
-    this.queryId = uuid;
+    this.queryId = queryId == null? UUID.randomUUID().toString() : queryId;
     if (hints != null) {
       this.hints = new HashSet<>(hints);
     } else {
@@ -77,10 +71,10 @@ public class ReadableQueryConfig {
    * Internal constructor used to create a {@link ReadableQueryConfig} from another {@link ReadableQueryConfig}.
    *
    * @param qc   The {@link ReadableQueryConfig} that should be used. May be null.
-   * @param uuid The UUID for the new {@link ReadableQueryConfig}. If null, a new UUID will be created.
+   * @param queryId The queryId for the new {@link ReadableQueryConfig}. If null, a new UUID will be created.
    */
-  protected ReadableQueryConfig(ReadableQueryConfig qc, UUID uuid) {
-    this.queryId = (uuid == null) ? UUID.randomUUID() : uuid;
+  protected ReadableQueryConfig(ReadableQueryConfig qc, String queryId) {
+    this.queryId = (queryId == null) ? UUID.randomUUID().toString() : queryId;
     this.hints = new HashSet<>();
     if (qc == null) {
       return;
@@ -95,7 +89,7 @@ public class ReadableQueryConfig {
     this.relevantSegmentIds.addAll(qc.relevantSegmentIds);
   }
 
-  public final UUID getQueryId() {
+  public final String getQueryId() {
     return this.queryId;
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/exporter/QueryImageExporter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/exporter/QueryImageExporter.java
@@ -76,7 +76,7 @@ public class QueryImageExporter implements Retriever {
   public List<ScoreElement> getSimilar(SegmentContainer sc, ReadableQueryConfig qc) {
     BufferedImage bimg = sc.getMostRepresentativeFrame().getImage().getBufferedImage();
     try {
-      String filename = (qc != null && qc.getQueryId() != null) ? qc.getQueryId().toString() : this.df.format(Calendar.getInstance().getTime());
+      String filename = (qc != null && qc.getQueryId() != null) ? qc.getQueryId() : this.df.format(Calendar.getInstance().getTime());
       ImageIO.write(bimg, "PNG", new File(folder, filename + ".png"));
     } catch (IOException e) {
       LOGGER.error(LogHelper.getStackTrace(e));

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/util/DBQueryIDGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/util/DBQueryIDGenerator.java
@@ -34,7 +34,7 @@ public class DBQueryIDGenerator {
    * uses {@link ReadableQueryConfig#getQueryId()} as a basis for postfix
    */
   public static String generateQueryID(String infix, ReadableQueryConfig qc) {
-    return qc == null ? generate(infix, "qc-null") : generate(infix, qc.getQueryId().toString().substring(0, 3));
+    return qc == null ? generate(infix, "qc-null") : generate(infix, qc.getQueryId().substring(0, 3));
   }
 
   private static String generate(String infix, String postfix) {


### PR DESCRIPTION
The main thing this PR does is that it makes sure that if a client provides a queryID, that is consistently used throughout the stack. In the process, we're also moving from a mix between `UUID` and `String` to `String` everywhere, as clients don't specify UUIDs and UUIDs have certain limitations we do not want to necessarily impose those on clients.