### PR TITLE
Adding Working CollectionBooleanRetriever to Default Config

### DIFF
--- a/cineast.json
+++ b/cineast.json
@@ -52,10 +52,11 @@
       ],
       "boolean": [
         {
-          "feature": "RangeBooleanRetriever", "weight": 1.0,
+          "feature": "CollectionBooleanRetriever", "weight": 1.0,
           "properties": {
-            "entity": "table_name",
-            "attribute": "text,option,range"
+            "entity": "cineast_segment",
+            "attribute": "segmentid,objectid",
+            "idCol": "segmentid"
           }
         }
       ]


### PR DESCRIPTION
This makes it so the default config works out of the box. The config example for the RangeBooleanRetriever is documented on the wiki: https://github.com/vitrivr/cineast/wiki/Useful-Config-Hints.

This is done in the context of https://github.com/vitrivr/vitrivr-ng/pull/124, where the corresponding functionality is added to frontend.