### PR TITLE
Fixed issue that would cause a deadlock during batch inserts.

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWriter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWriter.java
@@ -81,7 +81,7 @@ public final class CottontailWriter extends AbstractPersistencyWriter<Insert> {
         if (insert.size() >= Constants.MAX_PAGE_SIZE_BYTES) {
           LOGGER.trace("Inserting msg of size {} into {}", insert.size(), this.fqn);
           this.cottontail.client.insert(insert);
-          insert = new BatchInsert().into(this.fqn).columns(this.names);
+          insert = new BatchInsert().into(this.fqn).columns(this.names).txId(txId);
         }
       }
       if (insert.getBuilder().getInsertsCount() > 0) {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWriter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailWriter.java
@@ -81,7 +81,10 @@ public final class CottontailWriter extends AbstractPersistencyWriter<Insert> {
         if (insert.size() >= Constants.MAX_PAGE_SIZE_BYTES) {
           LOGGER.trace("Inserting msg of size {} into {}", insert.size(), this.fqn);
           this.cottontail.client.insert(insert);
-          insert = new BatchInsert().into(this.fqn).columns(this.names).txId(txId);
+          insert = new BatchInsert().into(this.fqn).columns(this.names);
+          if(useTransactions){
+            insert.txId(txId);
+          }
         }
       }
       if (insert.getBuilder().getInsertsCount() > 0) {


### PR DESCRIPTION
The issue is caused by the absence of a transaction ID for subsequent `BatchInsert` objects, which leads to a concurrent write transaction that is blocked bythe transaction initiated before.