### PR TITLE
Refactoring of POST handlers

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/APIEndpoint.java
@@ -20,8 +20,8 @@ import org.vitrivr.cineast.api.rest.OpenApiCompatHelper;
 import org.vitrivr.cineast.api.rest.handlers.actions.StatusInvocationHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.bool.FindDistinctElementsByColumnPostHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.bool.SelectFromTablePostHandler;
-import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindFeaturesByCategoryGetHandler;
-import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindFeaturesByEntityGetHandler;
+import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindFeaturesByCategoryPostHandler;
+import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindFeaturesByEntityPostHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindSegmentFeaturesGetHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindSegmentTextGetHandler;
 import org.vitrivr.cineast.api.rest.handlers.actions.feature.FindTagsForElementGetHandler;
@@ -412,8 +412,8 @@ public class APIEndpoint {
         new FindSegmentSimilarStagedPostHandler(retrievalLogic),
         new FindSegmentSimilarTemporalPostHandler(retrievalLogic),
         new FindSegmentFeaturesGetHandler(),
-        new FindFeaturesByCategoryGetHandler(),
-        new FindFeaturesByEntityGetHandler(),
+        new FindFeaturesByCategoryPostHandler(),
+        new FindFeaturesByEntityPostHandler(),
         new FindSegmentTextGetHandler(),
         /* Tags */
         new FindTagsAllGetHandler(),

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/feature/FindFeaturesByCategoryPostHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/feature/FindFeaturesByCategoryPostHandler.java
@@ -15,7 +15,7 @@ import org.vitrivr.cineast.api.util.QueryUtil;
 /**
  * Handler for the API call to retrieve all features for all objects for a given category.
  */
-public class FindFeaturesByCategoryGetHandler implements ParsingPostRestHandler<IdList, FeaturesByCategoryQueryResult> {
+public class FindFeaturesByCategoryPostHandler implements ParsingPostRestHandler<IdList, FeaturesByCategoryQueryResult> {
 
   public static final String ROUTE = "find/feature/all/by/category/{" + CATEGORY_NAME + "}";
 

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/feature/FindFeaturesByEntityPostHandler.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/rest/handlers/actions/feature/FindFeaturesByEntityPostHandler.java
@@ -15,7 +15,7 @@ import org.vitrivr.cineast.api.util.QueryUtil;
 /**
  * Handler for the API call to retrieve all features for all objects for a given table/entity name.
  */
-public class FindFeaturesByEntityGetHandler implements ParsingPostRestHandler<IdList, FeaturesByEntityQueryResult> {
+public class FindFeaturesByEntityPostHandler implements ParsingPostRestHandler<IdList, FeaturesByEntityQueryResult> {
 
   public static final String ROUTE = "find/feature/all/by/entity/{" + ENTITY_NAME + "}";
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1629,10 +1629,6 @@
             "type" : "string",
             "enum" : [ "PING", "Q_SIM", "Q_MLT", "Q_NESEG", "Q_SEG", "M_LOOKUP", "Q_TEMPORAL", "SESSION_START", "QR_START", "QR_END", "QR_ERROR", "QR_OBJECT", "QR_METADATA_O", "QR_METADATA_S", "QR_SEGMENT", "QR_SIMILARITY", "QR_TEMPORAL" ]
           },
-          "maxLength" : {
-            "type" : "number",
-            "format" : "float"
-          },
           "timeDistances" : {
             "type" : "array",
             "items" : {
@@ -1642,6 +1638,10 @@
           },
           "temporalQueryConfig" : {
             "$ref" : "#/components/schemas/TemporalQueryConfig"
+          },
+          "maxLength" : {
+            "type" : "number",
+            "format" : "float"
           }
         }
       },
@@ -1846,9 +1846,6 @@
       "Tag" : {
         "type" : "object",
         "properties" : {
-          "description" : {
-            "type" : "string"
-          },
           "name" : {
             "type" : "string"
           },
@@ -1857,6 +1854,9 @@
             "enum" : [ "REQUEST", "REQUIRE", "EXCLUDE" ]
           },
           "id" : {
+            "type" : "string"
+          },
+          "description" : {
             "type" : "string"
           }
         }


### PR DESCRIPTION
When using the API endpoints, it was noticed that two POST handlers were named GET handlers (FindFeaturesByCategoryGetHandler and FindFeaturesByEntityGetHandler). This naming issue is fixed with this commit. At the same time, the OpenApiSpecs were rebuilt.
However, the functionality of Cineast has not changed.