### PR TITLE
Removing unneeded post_checkout hook

### DIFF
--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Docker hub does a recursive clone, then checks the branch out,
-# so when a PR adds a submodule (or updates it), it fails.
-git submodule update --init


### PR DESCRIPTION
Since there are no more submodules, this hook is not needed anymore