### PR TITLE
Logging Fixes & Improvements

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
@@ -237,20 +237,20 @@ public interface DBSelector extends Closeable {
           }
         }
         // at this point, if there is an id list, the element is within that list
-        if (!el.domain.equals("*")) {
+        if (!el.domain().equals("*")) {
           if (!tuple.containsKey(DOMAIN_COL_NAME)) {
             return false;
           }
-          if (!tuple.get(DOMAIN_COL_NAME).getString().equals(el.domain)) {
+          if (!tuple.get(DOMAIN_COL_NAME).getString().equals(el.domain())) {
             return false;
           }
         }
         // at this point, if a domain is specified, the element matches that domain
-        if (!el.key.equals("*")) {
+        if (!el.key().equals("*")) {
           if (!tuple.containsKey(KEY_COL_NAME)) {
             return false;
           }
-          if (!tuple.get(KEY_COL_NAME).getString().equals(el.key)) {
+          if (!tuple.get(KEY_COL_NAME).getString().equals(el.key())) {
             return false;
           }
         }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
@@ -416,6 +416,10 @@ public final class CottontailSelector implements DBSelector {
 
   @Override
   public List<Map<String, PrimitiveTypeProvider>> getMetadataByIdAndSpec(List<String> ids, List<MetadataAccessSpecification> spec, String idColName, String dbQueryID) {
+    if (ids.isEmpty()) {
+      LOGGER.trace("No ids specified, not fetching any metadata for query id {}", dbQueryID);
+      return new ArrayList<>();
+    }
     final Query query = new Query(this.fqn).select("*", null).queryId(dbQueryID == null ? "md-id-spec" : dbQueryID);
     final Optional<Predicate> predicates = generateQueryFromMetadataSpec(spec);
     final Expression segmentIds = new Expression(idColName, "IN", ids.toArray());
@@ -430,11 +434,11 @@ public final class CottontailSelector implements DBSelector {
   public Optional<Predicate> generateQueryFromMetadataSpec(List<MetadataAccessSpecification> spec) {
     final List<Optional<Predicate>> atomics = spec.stream().map(s -> {
       List<Predicate> singleSpecPredicates = new ArrayList<>();
-      if (!s.domain.isEmpty() && !s.domain.equals("*")) {
-        singleSpecPredicates.add(new Expression(DOMAIN_COL_NAME, "=", s.domain));
+      if (!s.domain().isEmpty() && !s.domain().equals("*")) {
+        singleSpecPredicates.add(new Expression(DOMAIN_COL_NAME, "=", s.domain()));
       }
-      if (!s.key.isEmpty() && !s.key.equals("*")) {
-        singleSpecPredicates.add(new Expression(KEY_COL_NAME, "=", s.key));
+      if (!s.key().isEmpty() && !s.key().equals("*")) {
+        singleSpecPredicates.add(new Expression(KEY_COL_NAME, "=", s.key()));
       }
       return singleSpecPredicates.stream().reduce(And::new);
     }).collect(Collectors.toList());

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/MetadataAccessSpecification.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/MetadataAccessSpecification.java
@@ -1,22 +1,8 @@
 package org.vitrivr.cineast.core.db.dao;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Use '*' in either domain or key to retrieve simply all information. In general, if an empty specification list is provided, no metadata is returned.
  */
-public class MetadataAccessSpecification {
+public record MetadataAccessSpecification(MetadataType type, String domain, String key) {
 
-  public final MetadataType type;
-  public final String domain;
-  public final String key;
-
-  public MetadataAccessSpecification(
-      @JsonProperty("type") MetadataType type,
-      @JsonProperty("domain") String domain,
-      @JsonProperty("key") String key) {
-    this.type = type;
-    this.domain = domain;
-    this.key = key;
-  }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
@@ -144,14 +144,14 @@ public abstract class AbstractMetadataReader<R> extends AbstractEntityReader {
       spec = spec.stream().filter(Objects::nonNull).collect(Collectors.toList());
     }
     // filter non-object specs if this is an object reader
-    if (Objects.equals(this.tableName, MediaObjectMetadataDescriptor.ENTITY) && spec.stream().anyMatch(el -> el.type != MetadataType.OBJECT)) {
+    if (Objects.equals(this.tableName, MediaObjectMetadataDescriptor.ENTITY) && spec.stream().anyMatch(el -> el.type() != MetadataType.OBJECT)) {
       LOGGER.trace("provided spec-list includes non-object tuples, but this is an object reader. These will be ignored.");
-      spec = spec.stream().filter(el -> el.type == MetadataType.OBJECT).collect(Collectors.toList());
+      spec = spec.stream().filter(el -> el.type() == MetadataType.OBJECT).collect(Collectors.toList());
     }
     // filter non-segment specs if this is a segment reader
-    if (Objects.equals(this.tableName, MediaSegmentMetadataDescriptor.ENTITY) && spec.stream().anyMatch(el -> el.type != MetadataType.SEGMENT)) {
+    if (Objects.equals(this.tableName, MediaSegmentMetadataDescriptor.ENTITY) && spec.stream().anyMatch(el -> el.type() != MetadataType.SEGMENT)) {
       LOGGER.trace("provided spec-list includes non-segment tuples, but this is a segment reader. These will be ignored.");
-      spec = spec.stream().filter(el -> el.type == MetadataType.SEGMENT).collect(Collectors.toList());
+      spec = spec.stream().filter(el -> el.type() == MetadataType.SEGMENT).collect(Collectors.toList());
     }
     return spec;
   }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/runtime/RetrievalTask.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/runtime/RetrievalTask.java
@@ -59,7 +59,7 @@ public class RetrievalTask implements Callable<Pair<RetrievalTask, List<ScoreEle
     long stop = System.currentTimeMillis();
     RetrievalTaskMonitor.reportExecutionTime(retriever.getClass().getSimpleName(), stop - start);
     LOGGER.debug("{}.getSimilar() done in {} ms, {} results", retriever.getClass().getSimpleName(), stop - start, result.size());
-    return LOGGER.traceExit(new Pair<RetrievalTask, List<ScoreElement>>(this, result));
+    return new Pair<>(this, result);
   }
 
   private void nameThread() {

--- a/cineast-runtime/src/main/resources/log4j2.xml
+++ b/cineast-runtime/src/main/resources/log4j2.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
+  <Properties>
+    <Property name="loggingPattern">[%d{MM-dd HH:mm:ss.SSS}][%-5level][%t] %C{1} - %msg%n</Property>
+  </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %p %c{1.} - %msg%n"/>
       <ThresholdFilter level="DEBUG" onMatch="ACCEPT" onMismatch="DENY"/>
     </Console>
     <RollingFile name="File">
-      <DefaultRolloverStrategy max="5"/>
       <FileName>logs/cineast.log</FileName>
       <FilePattern>logs/%d{yyyy-MM-dd-hh}-%i.log.zip</FilePattern>
       <PatternLayout pattern="${loggingPattern}"/>
       <Policies>
-        <SizeBasedTriggeringPolicy size="2000 KB"/>
+        <SizeBasedTriggeringPolicy size="5000 KB"/>
       </Policies>
+      <DefaultRolloverStrategy max="5"/>
       <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
     </RollingFile>
   </Appenders>
   <Loggers>
+    <logger name="io" level="ERROR">
+    </logger>
+    <logger name="org" level="INFO" additivity="true">
+    </logger>
+    <logger name="org.vitrivr.cineast" level="TRACE" additivity="true">
+    </logger>
     <Root level="info">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
     </Root>
-    <logger additivity="true" level="INFO" name="org">
-    </logger>
-    <logger additivity="true" level="TRACE" name="org.vitrivr.cineast">
-    </logger>
-    <logger level="ERROR" name="io">
-    </logger>
   </Loggers>
-  <Properties>
-    <Property name="loggingPattern">[%d{MM-dd HH:mm:ss.SSS}][%-5level][%t] %C{1} - %msg%n</Property>
-  </Properties>
 </Configuration>


### PR DESCRIPTION
- fixing log4j config, 
- stopping cineast from logging multiple MB per query because all results are logged (in an unreadable format since the class did not get stringified meaningfully
- fixing rare exception where the CottontailSelector would crash if no ids to fetch were given. 
- Moving MetadataAccessSpecification also to record.