### PR TITLE
Fixed model loading.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.11.4'
+    version = '3.11.5'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CLIPImage.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CLIPImage.java
@@ -87,7 +87,7 @@ public class CLIPImage extends AbstractFeatureModule {
     return getSimilar(embeddingArray, queryConfig);
   }
 
-  private void initializeModel() {
+  private synchronized static void initializeModel() {
     if (model == null) {
       model = SavedModelBundle.load(RESOURCE_PATH + EMBEDDING_MODEL);
     }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CLIPText.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CLIPText.java
@@ -60,7 +60,7 @@ public class CLIPText implements Retriever {
     loadModel();
   }
 
-  private static void loadModel() {
+  private synchronized static void loadModel() {
     if (model == null) {
       model = SavedModelBundle.load(RESOURCE_PATH + EMBEDDING_MODEL);
     }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SkeletonPose.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SkeletonPose.java
@@ -57,7 +57,7 @@ public class SkeletonPose extends AbstractFeatureModule {
   private static final String PERSON_ID_COL = "person";
   private static final String FEATURE_COL = "skeleton";
   private static final String WEIGHT_COL = "weights";
-  private final PoseDetector detector = new MergingPoseDetector();
+  private static PoseDetector detector;
 
   public SkeletonPose() {
     super("features_skeletonpose", (float) (16 * Math.PI), 12);
@@ -129,7 +129,14 @@ public class SkeletonPose extends AbstractFeatureModule {
     this.phandler.persist(tuples);
   }
 
+  private synchronized static void initializeDetector() {
+    if (detector == null) {
+      detector = new MergingPoseDetector();
+    }
+  }
+
   private synchronized List<Skeleton> detectSkeletons(MultiImage img) {
+    initializeDetector();
     return detector.detectPoses(img.getBufferedImage());
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/VisualTextCoEmbedding.java
@@ -130,7 +130,7 @@ public class VisualTextCoEmbedding extends AbstractFeatureModule {
     return super.getSimilar(segmentId, queryConfig);
   }
 
-  private void initializeTextEmbedding() {
+  private synchronized static void initializeTextEmbedding() {
     if (textEmbedding == null) {
       textEmbedding = SavedModelBundle.load(RESOURCE_PATH + TEXT_EMBEDDING_MODEL);
     }
@@ -139,7 +139,7 @@ public class VisualTextCoEmbedding extends AbstractFeatureModule {
     }
   }
 
-  private void initializeVisualEmbedding() {
+  private synchronized static void initializeVisualEmbedding() {
     if (visualEmbedding == null) {
       visualEmbedding = InceptionResnetV2.getModel();
     }


### PR DESCRIPTION
- Ensuring models are only loaded once through synchronized static methods.
- Ensuring the SkeletonPose model is only loaded when needed for extraction and not for retrieval.

Closes #303.
Closes #311.