### PR TITLE
Fixing CI branch names

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '19 10 * * 0'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master, dev, vbs, lsc ]
+    branches: [ main, dev, vbs, lsc ]
   pull_request:
-    branches: [ master, dev, vbs, lsc ]
+    branches: [ main, dev, vbs, lsc ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.11.6'
+    version = '3.12.0'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'


### PR DESCRIPTION
Additionally, bumping to v3.12.0 so we can create a new release based on the new head commit hash