### PR TITLE
Making decorator for text retrieval configurable

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/AudioTranscriptionSearch.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/AudioTranscriptionSearch.java
@@ -1,6 +1,6 @@
 package org.vitrivr.cineast.core.features;
 
-import java.util.LinkedHashMap;
+import java.util.Map;
 import org.vitrivr.cineast.core.data.entities.SimpleFulltextFeatureDescriptor;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.features.abstracts.AbstractTextRetriever;
@@ -16,7 +16,7 @@ public class AudioTranscriptionSearch extends AbstractTextRetriever {
     super(AudioTranscriptionSearch.AUDIO_TRANSCRIPTION_TABLE_NAME);
   }
 
-  public AudioTranscriptionSearch(LinkedHashMap<String, String> properties) {
+  public AudioTranscriptionSearch(Map<String, String> properties) {
     super(AUDIO_TRANSCRIPTION_TABLE_NAME, properties);
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/AudioTranscriptionSearch.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/AudioTranscriptionSearch.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.core.features;
 
+import java.util.LinkedHashMap;
 import org.vitrivr.cineast.core.data.entities.SimpleFulltextFeatureDescriptor;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.features.abstracts.AbstractTextRetriever;
@@ -13,6 +14,10 @@ public class AudioTranscriptionSearch extends AbstractTextRetriever {
    */
   public AudioTranscriptionSearch() {
     super(AudioTranscriptionSearch.AUDIO_TRANSCRIPTION_TABLE_NAME);
+  }
+
+  public AudioTranscriptionSearch(LinkedHashMap<String, String> properties) {
+    super(AUDIO_TRANSCRIPTION_TABLE_NAME, properties);
   }
 
   /**

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CollectionBooleanRetriever.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/CollectionBooleanRetriever.java
@@ -3,8 +3,8 @@ package org.vitrivr.cineast.core.features;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.vitrivr.cineast.core.db.RelationalOperator;
 import org.vitrivr.cineast.core.features.abstracts.BooleanRetriever;
 
@@ -22,7 +22,7 @@ public class CollectionBooleanRetriever extends BooleanRetriever {
     super(entity, attributes);
   }
 
-  public CollectionBooleanRetriever(LinkedHashMap<String, String> properties) {
+  public CollectionBooleanRetriever(Map<String, String> properties) {
     super(properties);
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/ProvidedOcrSearch.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/ProvidedOcrSearch.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.core.features;
 
+import java.util.LinkedHashMap;
 import org.vitrivr.cineast.core.features.abstracts.AbstractTextRetriever;
 
 /**
@@ -15,4 +16,9 @@ public class ProvidedOcrSearch extends AbstractTextRetriever {
   public ProvidedOcrSearch() {
     super(ProvidedOcrSearch.PROVIDED_OCR_SEARCH_TABLE_NAME);
   }
+
+  public ProvidedOcrSearch(LinkedHashMap<String, String> properties) {
+    super(ProvidedOcrSearch.PROVIDED_OCR_SEARCH_TABLE_NAME, properties);
+  }
+
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/ProvidedOcrSearch.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/ProvidedOcrSearch.java
@@ -1,6 +1,6 @@
 package org.vitrivr.cineast.core.features;
 
-import java.util.LinkedHashMap;
+import java.util.Map;
 import org.vitrivr.cineast.core.features.abstracts.AbstractTextRetriever;
 
 /**
@@ -17,7 +17,7 @@ public class ProvidedOcrSearch extends AbstractTextRetriever {
     super(ProvidedOcrSearch.PROVIDED_OCR_SEARCH_TABLE_NAME);
   }
 
-  public ProvidedOcrSearch(LinkedHashMap<String, String> properties) {
+  public ProvidedOcrSearch(Map<String, String> properties) {
     super(ProvidedOcrSearch.PROVIDED_OCR_SEARCH_TABLE_NAME, properties);
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/RangeBooleanRetriever.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/RangeBooleanRetriever.java
@@ -4,8 +4,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.vitrivr.cineast.core.data.providers.primitive.PrimitiveProviderComparator;
 import org.vitrivr.cineast.core.data.providers.primitive.PrimitiveTypeProvider;
 import org.vitrivr.cineast.core.db.RelationalOperator;
@@ -32,7 +32,7 @@ public class RangeBooleanRetriever extends BooleanRetriever {
     super(entity, attributes);
   }
 
-  public RangeBooleanRetriever(LinkedHashMap<String, String> properties) {
+  public RangeBooleanRetriever(Map<String, String> properties) {
     super(properties);
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SkeletonPose.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SkeletonPose.java
@@ -208,7 +208,7 @@ public class SkeletonPose extends AbstractFeatureModule {
         results.add(new SegmentScoreElement(segment, this.correspondence.applyAsDouble(minDist)));
       }
       results.sort(SegmentScoreElement.SCORE_COMPARATOR.reversed());
-      return results.subList(0, Math.min(results.size(), qc.getRawResultsPerModule()) - 1);
+      return results.subList(0, Math.min(results.size(), qc.getResultsPerModule()) - 1);
     }
 
     //more than query skeleton

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SpatialDistance.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SpatialDistance.java
@@ -4,8 +4,8 @@ import com.fathzer.soft.javaluator.DoubleEvaluator;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +50,7 @@ public class SpatialDistance extends MetadataFeatureModule<Location> {
     correspondenceFunction = CorrespondenceFunction.hyperbolic(halfSimilarityDistance);
   }
 
-  public SpatialDistance(LinkedHashMap<String, String> properties) {
+  public SpatialDistance(Map<String, String> properties) {
     super(2, properties);
     String halfSimDistFromConfig = properties.getOrDefault("halfSimilarityDistance", "1000.0/3.0");
     halfSimilarityDistance = parseAndEvaluateHalfSimilarityDistance(halfSimDistFromConfig);

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SubtitleFulltextSearch.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/SubtitleFulltextSearch.java
@@ -1,16 +1,23 @@
 package org.vitrivr.cineast.core.features;
 
+import java.util.Map;
 import org.vitrivr.cineast.core.data.entities.SimpleFulltextFeatureDescriptor;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.features.abstracts.AbstractTextRetriever;
 
 public class SubtitleFulltextSearch extends AbstractTextRetriever {
 
+  private static final String SUBTITLE_TABLE_NAME = "features_subtitles";
+
   /**
    * Default constructor for {@link SubtitleFulltextSearch}.
    */
   public SubtitleFulltextSearch() {
-    super("features_asr");
+    super(SUBTITLE_TABLE_NAME);
+  }
+
+  public SubtitleFulltextSearch(Map<String, String> properties) {
+    super(SUBTITLE_TABLE_NAME, properties);
   }
 
   /**

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/AbstractTextRetriever.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/AbstractTextRetriever.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -69,10 +68,10 @@ public abstract class AbstractTextRetriever implements Retriever, Extractor {
    * @param tableName Name of the table/entity used to store the data
    */
   public AbstractTextRetriever(String tableName) {
-    this(tableName, new LinkedHashMap<>());
+    this(tableName, new HashMap<>());
   }
 
-  public AbstractTextRetriever(String defaultTableName, LinkedHashMap<String, String> properties) {
+  public AbstractTextRetriever(String defaultTableName, Map<String, String> properties) {
     if (defaultTableName == null) {
       throw new IllegalStateException("If no entity is provided by the underlying feature, it needs to be specified in properties");
     }
@@ -80,7 +79,7 @@ public abstract class AbstractTextRetriever implements Retriever, Extractor {
     this.decorator = properties.getOrDefault("decorator", "");
   }
 
-  public AbstractTextRetriever(LinkedHashMap<String, String> properties) {
+  public AbstractTextRetriever(Map<String, String> properties) {
     this(properties.get("entity"), properties);
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/AbstractTextRetriever.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/abstracts/AbstractTextRetriever.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -47,6 +48,12 @@ public abstract class AbstractTextRetriever implements Retriever, Extractor {
    * Name of the table/entity used to store the data.
    */
   private final String tableName;
+
+  /**
+   * decorator for lucene queries
+   */
+  private final String decorator;
+
   /**
    * The {@link DBSelector} used for database lookup.
    */
@@ -62,7 +69,19 @@ public abstract class AbstractTextRetriever implements Retriever, Extractor {
    * @param tableName Name of the table/entity used to store the data
    */
   public AbstractTextRetriever(String tableName) {
-    this.tableName = tableName;
+    this(tableName, new LinkedHashMap<>());
+  }
+
+  public AbstractTextRetriever(String defaultTableName, LinkedHashMap<String, String> properties) {
+    if (defaultTableName == null) {
+      throw new IllegalStateException("If no entity is provided by the underlying feature, it needs to be specified in properties");
+    }
+    this.tableName = properties.getOrDefault("entity", defaultTableName);
+    this.decorator = properties.getOrDefault("decorator", "");
+  }
+
+  public AbstractTextRetriever(LinkedHashMap<String, String> properties) {
+    this(properties.get("entity"), properties);
   }
 
   @Override
@@ -171,7 +190,7 @@ public abstract class AbstractTextRetriever implements Retriever, Extractor {
    * Implementing features can transform individual query terms. By default, nothing happens
    */
   protected String enrichQueryTerm(String queryTerm) {
-    return queryTerm;
+    return queryTerm + this.decorator;
   }
 
   /**

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/CliUtils.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/CliUtils.java
@@ -118,6 +118,5 @@ public class CliUtils {
       }
       System.out.println();
     });
-    retrieval.shutdown();
   }
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/TagRetrievalCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/TagRetrievalCommand.java
@@ -29,6 +29,7 @@ public class TagRetrievalCommand extends AbstractCineastCommand {
     retrievers.add(new SegmentTags());
 
     CliUtils.retrieveAndLog(retrievers, retrieval, limit, printDetail, qc);
+    retrieval.shutdown();
     System.out.println("Done");
   }
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/TextRetrievalCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/TextRetrievalCommand.java
@@ -2,11 +2,11 @@ package org.vitrivr.cineast.standalone.cli;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
+import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import org.vitrivr.cineast.core.data.query.containers.TextQueryTermContainer;
 import org.vitrivr.cineast.core.features.AudioTranscriptionSearch;
-import org.vitrivr.cineast.core.features.OCRSearch;
 import org.vitrivr.cineast.core.features.SubtitleFulltextSearch;
 import org.vitrivr.cineast.core.features.retriever.Retriever;
 import org.vitrivr.cineast.standalone.config.Config;
@@ -30,10 +30,14 @@ public class TextRetrievalCommand extends AbstractCineastCommand {
     System.out.println("Querying for text " + text);
     TextQueryTermContainer qc = new TextQueryTermContainer(text);
     List<Retriever> retrievers = new ArrayList<>();
+    Config.sharedConfig().getRetriever().getRetrieversByCategory("ocr").forEach(retriever -> {
+      CliUtils.retrieveAndLog(Lists.newArrayList(retriever), retrieval, limit, printDetail, qc);
+      return true;
+    });
     retrievers.add(new SubtitleFulltextSearch());
-    retrievers.add(new OCRSearch());
     retrievers.add(new AudioTranscriptionSearch());
     CliUtils.retrieveAndLog(retrievers, retrieval, limit, printDetail, qc);
+    retrieval.shutdown();
     System.out.println("Done");
   }
 }


### PR DESCRIPTION
Some time ago, each term used to be decorated with `~` at the end for fuzzy matches. This got lost at some point, which leads to a query for `JAMES` to not match `AMES` in an OCR column. To fix this, this PR adds configurable decorators for all text-retrieval classes. Default behavior stays the same.

Additionally, it adds the option to configure entity-names for text retrieval classes and fixes rare edge-cases where batch-import would cause problems.