### PR TITLE
Implemented OS switch so macOS builds use CPU version of TensorFlow.

### DIFF
--- a/cineast-core/build.gradle
+++ b/cineast-core/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -96,7 +98,10 @@ dependencies {
     implementation 'org.mockito:mockito-inline:4.5.1'
 
     /** Tensorflow (Java). */
-    api group: "org.tensorflow", name: "tensorflow-core-platform-gpu", version: version_tensorflow
+    if (DefaultNativePlatform.currentOperatingSystem.isMacOsX())
+        api group: "org.tensorflow", name: "tensorflow-core-platform", version: version_tensorflow
+    else
+        api group: "org.tensorflow", name: "tensorflow-core-platform-gpu", version: version_tensorflow
 
 
     /** Apache Commons Libraries */


### PR DESCRIPTION
Fixes #313.

Tested to work as expected with builds on macOS and Ubuntu.