### PR TITLE
Explicitly specifying type as Map for constructors

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/util/ReflectionHelper.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/util/ReflectionHelper.java
@@ -2,6 +2,7 @@ package org.vitrivr.cineast.core.util;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -282,6 +283,13 @@ public class ReflectionHelper {
    */
   public static <T> T instantiate(Class<? extends T> cl, Class[] types, Object... args) {
     try {
+      // for constructors expecting maps.
+      for (int i = 0, typesLength = types.length; i < typesLength; i++) {
+        if (Arrays.stream(types[0].getInterfaces()).anyMatch(c -> c == Map.class)) {
+          types[i] = Map.class;
+        }
+      }
+
       Constructor<? extends T> con = cl.getConstructor(types);
       return con.newInstance(args);
     } catch (InvocationTargetException e) {


### PR DESCRIPTION
Changes in #324 made all constructors take `Map` as parameter if there are properties. However, this requires explictly searching for `Map` as class type in reflection. If this is not done, an exception is thrown:

```
2022-07-26 07:55:04.238 [ssq-0] ERROR o.v.c.c.u.ReflectionHelper - java.lang.NoSuchMethodException: org.vitrivr.cineast.core.features.ProvidedOcrSearch.<init>(java.util.LinkedHashMap)
        at java.base/java.lang.Class.getConstructor0(Class.java:3585)
        at java.base/java.lang.Class.getConstructor(Class.java:2271)
        at org.vitrivr.cineast.core.util.ReflectionHelper.instantiate(ReflectionHelper.java:285)
        at org.vitrivr.cineast.core.util.ReflectionHelper.instantiate(ReflectionHelper.java:272)
``` 

This PR fixes that by explictly searching for Map constructors if there is a map passed.