### PR TITLE
Changed default number of threads for import command.

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/cli/ImportCommand.java
@@ -26,7 +26,7 @@ public class ImportCommand extends AbstractCineastCommand {
   private String input;
 
   @Option(name = {"--threads"}, description = "Level of parallelization for import")
-  private int threads = 2;
+  private int threads = 1;
 
   @Option(name = {"-b", "--batchsize"}, description = "The batch size used for the import. Imported data will be persisted in batches of the specified size.")
   private int batchsize = 500;


### PR DESCRIPTION
Set the default number of threads for the import command to 1 down from 2 to avoid issues caused by parallelization for new or inexperienced users.

This is necessary to avoid the issue discussed [here](https://github.com/vitrivr/cottontaildb/discussions/122#discussion-4064455) for users unaware of the problem who might not know that an import cannot run successfully with all default settings using the current Cottontail DB version.

In addition to allowing default parameters to work around this issue, I think this is a good idea anyways, as no parallelism is the safest default value.