### PR TITLE
Visual-Text Co-Embedding image retrieval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     group = 'org.vitrivr'
 
     /* Our current version, on dev branch this should always be release+1-SNAPSHOT */
-    version = '3.12.1'
+    version = '3.12.2'
 
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'


### PR DESCRIPTION
Previously the visual-text co-embedding only allowed retrieval with text terms and would even retrieve using the empty string provided by default if no text term was specified.
This has been fixed with appropriate error messages and returns.
Retrieval using image terms was implemented.