### PR TITLE
Preventing unnecessary data being sent for text queries

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/cottontaildb/CottontailSelector.java
@@ -346,7 +346,7 @@ public final class CottontailSelector implements DBSelector {
 
     /* TODO Cottontail calls this a distance in its documentation, but it's actually a score. See the tests - that's why we order DESC and not ASC */
     final Query query = new Query(this.fqn)
-        .select("*", null)
+        .select("id", null)
         .fulltext(fieldname, predicate, DB_DISTANCE_VALUE_QUALIFIER)
         .queryId(generateQueryID("ft-rows", queryConfig))
         .order(DB_DISTANCE_VALUE_QUALIFIER, Direction.DESC)

--- a/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
+++ b/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
@@ -63,7 +63,7 @@ public abstract class DBBooleanIntegrationTest<R> {
   @BeforeAll
   void checkConnection() {
     provider = provider();
-    assumeTrue(provider!=null);
+    assumeTrue(provider != null);
     selector = provider.getSelector();
     LOGGER.info("Trying to establish connection to Database");
     assumeTrue(selector.ping(), "Connection to database could not be established");
@@ -76,7 +76,7 @@ public abstract class DBBooleanIntegrationTest<R> {
 
   @BeforeEach
   void setupTest() {
-    assumeTrue(provider!=null);
+    assumeTrue(provider != null);
     dropTables();
     createTables();
     fillData();
@@ -168,9 +168,7 @@ public abstract class DBBooleanIntegrationTest<R> {
     this.selector.open(testTableName);
     int idToCheck = TABLE_CARD - 1;
     final List<Map<String, PrimitiveTypeProvider>> result = selector.getFulltextRows(1, DATA_COL_NAME_1, queryConfig, "string-data-" + idToCheck);
-    Assertions.assertEquals(result.get(0).get(DATA_COL_NAME_1).getString(), "string-data-" + idToCheck);
-    Assertions.assertEquals(result.get(0).get(DATA_COL_NAME_2).getInt(), -idToCheck);
-    Assertions.assertEquals(result.get(0).get(DATA_COL_NAME_3).getInt(), (idToCheck + TABLE_CARD));
+    Assertions.assertEquals(result.get(0).get(ID_COL_NAME).getInt(), idToCheck);
   }
 
   @Test


### PR DESCRIPTION
Speeding up text retrieval by preventing text being sent back from cottontail. 
Specifically, previously Cottontail sent back the distance twice and the full text which was stored. Now, only id + distance are sent.