### PR TITLE
Enable Gradle parallel builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.parallel=true
 # Dependency versions
 version_airline=2.8.5
 version_boofcv=0.28


### PR DESCRIPTION
This reduces the build time of `shadowJar` by 50~65% on my end (using Docker, no caching involved). However, fetching and compressing `externalFiles` is still the most time consuming task.