### PR TITLE
Fixing CLI not exiting properly

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
@@ -69,5 +69,6 @@ public class Main {
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
+    System.exit(0);
   }
 }


### PR DESCRIPTION
This PR fixes #349. It does not interfere with the aim of #345, as there is a while(true) loop if the CLI is not enabled.