### PR TITLE
Fixed #353 by respecting config value for segmenter

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/audio/ConstantLengthAudioSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/audio/ConstantLengthAudioSegmenter.java
@@ -1,10 +1,15 @@
 package org.vitrivr.cineast.core.extraction.segmenter.audio;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Sets;
 import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.frames.AudioFrame;
@@ -167,8 +172,8 @@ public class ConstantLengthAudioSegmenter implements Segmenter<AudioFrame> {
    * Returns {@link MediaType#AUDIO}, as this {@link Segmenter} is for audio.
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.AUDIO;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.AUDIO);
   }
 
   /**

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/audio/ConstantLengthAudioSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/audio/ConstantLengthAudioSegmenter.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.frames.AudioFrame;
 import org.vitrivr.cineast.core.data.segments.AudioSegment;
@@ -160,6 +161,14 @@ public class ConstantLengthAudioSegmenter implements Segmenter<AudioFrame> {
         this.decoder.close();
       }
     }
+  }
+
+  /**
+   * Returns {@link MediaType#AUDIO}, as this {@link Segmenter} is for audio.
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.AUDIO;
   }
 
   /**

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/general/Segmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/general/Segmenter.java
@@ -1,5 +1,6 @@
 package org.vitrivr.cineast.core.extraction.segmenter.general;
 
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.extraction.decode.general.Decoder;
@@ -39,4 +40,10 @@ public interface Segmenter<A> extends Runnable, AutoCloseable {
    */
   @Override
   void close();
+
+  /**
+   * Specifies for which media type this segmenter is
+   * @return The {@link MediaType} this {@link Segmenter} is for.
+   */
+  MediaType getMediaType();
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/general/Segmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/general/Segmenter.java
@@ -5,6 +5,8 @@ import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
 import org.vitrivr.cineast.core.extraction.decode.general.Decoder;
 
+import java.util.Set;
+
 /**
  * {@link Segmenter}s split a media file into chunks (segments). The nature of that chunk is specific to the media type and the{@link Segmenter}s implementation. A segment could be anything from a shot of a video to an arbitrary part of song or just a single image.
  */
@@ -42,8 +44,8 @@ public interface Segmenter<A> extends Runnable, AutoCloseable {
   void close();
 
   /**
-   * Specifies for which media type this segmenter is
-   * @return The {@link MediaType} this {@link Segmenter} is for.
+   * Specifies for which media types this segmenter is
+   * @return The set of {@link MediaType}s this {@link Segmenter} is for.
    */
-  MediaType getMediaType();
+  Set<MediaType> getMediaTypes();
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSegmenter.java
@@ -2,6 +2,9 @@ package org.vitrivr.cineast.core.extraction.segmenter.image;
 
 import java.awt.image.BufferedImage;
 import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.raw.CachedDataFactory;
 import org.vitrivr.cineast.core.data.segments.ImageSegment;
@@ -61,7 +64,7 @@ public class ImageSegmenter extends PassthroughSegmenter<BufferedImage> {
    * @return
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.IMAGE;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.IMAGE);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSegmenter.java
@@ -2,6 +2,7 @@ package org.vitrivr.cineast.core.extraction.segmenter.image;
 
 import java.awt.image.BufferedImage;
 import java.util.Map;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.raw.CachedDataFactory;
 import org.vitrivr.cineast.core.data.segments.ImageSegment;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
@@ -53,5 +54,14 @@ public class ImageSegmenter extends PassthroughSegmenter<BufferedImage> {
   @Override
   protected SegmentContainer getSegmentFromContent(BufferedImage content) {
     return new ImageSegment(content, this.factory);
+  }
+
+  /**
+   * Returns {@link MediaType#IMAGE}, as this {@link Segmenter} is for images
+   * @return
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.IMAGE;
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
@@ -132,7 +132,7 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
   }
 
   /**
-   * Returns {@link MediaType#IMAGE}, as this {@link Segmenter} is for images
+   * Returns {@link MediaType#IMAGE_SEQUENCE}, as this {@link Segmenter} is for image sequences
    * @return
    */
   @Override

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
@@ -127,4 +127,13 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
       this.running = false;
     }
   }
+
+  /**
+   * Returns {@link MediaType#IMAGE}, as this {@link Segmenter} is for images
+   * @return
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.IMAGE;
+  }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
@@ -4,7 +4,10 @@ import java.awt.image.BufferedImage;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.data.MediaType;
@@ -133,7 +136,7 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
    * @return
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.IMAGE;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.IMAGE);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
@@ -137,6 +137,6 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
    */
   @Override
   public Set<MediaType> getMediaTypes() {
-    return Sets.newHashSet(MediaType.IMAGE);
+    return Sets.newHashSet(MediaType.IMAGE_SEQUENCE);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/ConstantLengthVideoSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/ConstantLengthVideoSegmenter.java
@@ -1,9 +1,12 @@
 package org.vitrivr.cineast.core.extraction.segmenter.video;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.collect.Sets;
 import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
@@ -89,8 +92,8 @@ public class ConstantLengthVideoSegmenter implements Segmenter<VideoFrame> {
    * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.VIDEO;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.VIDEO);
   }
 
   @Override

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/ConstantLengthVideoSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/ConstantLengthVideoSegmenter.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
 import org.vitrivr.cineast.core.data.segments.SegmentContainer;
@@ -82,6 +83,14 @@ public class ConstantLengthVideoSegmenter implements Segmenter<VideoFrame> {
         this.decoder.close();
       }
     }
+  }
+
+  /**
+   * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.VIDEO;
   }
 
   @Override

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/TRECVidMSRSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/TRECVidMSRSegmenter.java
@@ -7,13 +7,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;
@@ -281,7 +279,7 @@ public class TRECVidMSRSegmenter implements Segmenter<VideoFrame> {
    * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.VIDEO;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.VIDEO);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/TRECVidMSRSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/TRECVidMSRSegmenter.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
@@ -274,5 +275,13 @@ public class TRECVidMSRSegmenter implements Segmenter<VideoFrame> {
     synchronized (this) {
       this.running = false;
     }
+  }
+
+  /**
+   * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.VIDEO;
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/V3CMSBSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/V3CMSBSegmenter.java
@@ -6,13 +6,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;
@@ -288,7 +286,7 @@ public class V3CMSBSegmenter implements Segmenter<VideoFrame> {
    * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.VIDEO;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.VIDEO);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/V3CMSBSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/V3CMSBSegmenter.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
 import org.vitrivr.cineast.core.data.frames.VideoFrame;
@@ -281,5 +282,13 @@ public class V3CMSBSegmenter implements Segmenter<VideoFrame> {
     synchronized (this) {
       this.running = false;
     }
+  }
+
+  /**
+   * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.VIDEO;
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/VideoHistogramSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/VideoHistogramSegmenter.java
@@ -1,12 +1,10 @@
 package org.vitrivr.cineast.core.extraction.segmenter.video;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -275,7 +273,7 @@ public class VideoHistogramSegmenter implements Segmenter<VideoFrame> {
    * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
    */
   @Override
-  public MediaType getMediaType() {
-    return MediaType.VIDEO;
+  public Set<MediaType> getMediaTypes() {
+    return Sets.newHashSet(MediaType.VIDEO);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/VideoHistogramSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/video/VideoHistogramSegmenter.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.data.Histogram;
+import org.vitrivr.cineast.core.data.MediaType;
 import org.vitrivr.cineast.core.data.Pair;
 import org.vitrivr.cineast.core.data.entities.MediaObjectDescriptor;
 import org.vitrivr.cineast.core.data.entities.MediaSegmentDescriptor;
@@ -268,5 +269,13 @@ public class VideoHistogramSegmenter implements Segmenter<VideoFrame> {
       }
     }
     return true;
+  }
+
+  /**
+   * Returns {@link MediaType#VIDEO}, as this {@link Segmenter} is for video
+   */
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.VIDEO;
   }
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
@@ -131,7 +131,7 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
 
       @Override
       public Set<MediaType> getMediaTypes() {
-        return Sets.newHashSet(MediaType.MODEL3D);
+        return Sets.newHashSet(MediaType.values());
       }
     }));
     // #353: Respect the given segmenter


### PR DESCRIPTION
Previously, the GenericExtractionItemHandler did not respect the config-provided segmenter, which is being fixed by this PR.

If no segmenter is specified, reasonable defaults are used per media type, this logic was not changed.