### PR TITLE
Fixed segmenter config not usable due to broken code

### DIFF
--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/run/GenericExtractionItemHandler.java
@@ -136,12 +136,11 @@ public class GenericExtractionItemHandler implements Runnable, ExtractionItemPro
     }));
     // #353: Respect the given segmenter
     final Set<MediaType> segmenterTypes;
-    try (Segmenter<Object> segmenter = context.newSegmenter()) {
-      segmenterTypes = segmenter.getMediaTypes();
-      segmenterTypes.forEach(t -> {
-        handlers.put(t, new ImmutablePair<>(handlers.get(t).getLeft(), () -> segmenter));
-      });
-    }
+    final Segmenter<Object> segmenter = context.newSegmenter();
+    segmenterTypes = segmenter.getMediaTypes();
+    segmenterTypes.forEach(t -> {
+      handlers.put(t, new ImmutablePair<>(handlers.get(t).getLeft(), () -> segmenter));
+    });
 
     //Config overwrite
     Config.sharedConfig().getDecoders().forEach((type, decoderConfig) -> {


### PR DESCRIPTION
With the current version on main, the segmenter is being closed upon initialisation. Obviously, this is not very helpful and leads to the extraction being unable to start.