### PR TITLE
Refactoring Object Id Generation

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/data/entities/MediaObjectDescriptor.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/data/entities/MediaObjectDescriptor.java
@@ -10,8 +10,6 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.vitrivr.cineast.core.data.ExistenceCheck;
 import org.vitrivr.cineast.core.data.MediaType;
-import org.vitrivr.cineast.core.db.dao.reader.MediaObjectReader;
-import org.vitrivr.cineast.core.extraction.idgenerator.ObjectIdGenerator;
 
 
 public class MediaObjectDescriptor implements ExistenceCheck {
@@ -64,26 +62,6 @@ public class MediaObjectDescriptor implements ExistenceCheck {
     this.exists = exists;
     this.contentURL = ""; //FIXME this probably need some kind of resolver to be constructed properly
     // Config.sharedConfig().getApi().getObjectLocation() + path;
-  }
-
-  /**
-   * Convenience method to create a MediaObjectDescriptor marked as new. The method will assign a new ID to this MediaObjectDescriptor using the provided ObjectIdGenerator.
-   *
-   * @param generator ObjectIdGenerator used for ID generation.
-   * @param path      The Path that points to the file for which a new MediaObjectDescriptor should be created.
-   * @param type      MediaType of the new MediaObjectDescriptor
-   * @param lookup    MediaObjectReader to prevent the assignment of already used ids
-   * @return A new MediaObjectDescriptor
-   */
-  public static MediaObjectDescriptor newMultimediaObjectDescriptor(
-      ObjectIdGenerator generator, Path path, MediaType type, MediaObjectReader lookup) {
-    String objectId;
-    do {
-      objectId = generator.next(path, type);
-    } while (lookup != null && lookup.lookUpObjectById(objectId).exists());
-
-    return new MediaObjectDescriptor(objectId,
-        getFileName(path), path.toString(), type, false);
   }
 
   public static String cleanPath(Path path) {

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/FileNameObjectIdGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/FileNameObjectIdGenerator.java
@@ -2,6 +2,7 @@ package org.vitrivr.cineast.core.extraction.idgenerator;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.io.FilenameUtils;
 import org.vitrivr.cineast.core.data.MediaType;
 
@@ -24,18 +25,19 @@ public class FileNameObjectIdGenerator implements ObjectIdGenerator {
   }
 
   public FileNameObjectIdGenerator(Map<String, String> properties) {
-    String prefixProp = properties.get(PROPERTY_NAME_PREFIX);
-    prefix = prefixProp == null || prefixProp.equalsIgnoreCase("true");
+    String prefixProp = properties.getOrDefault(PROPERTY_NAME_PREFIX, "true");
+    prefix = prefixProp.equalsIgnoreCase("true");
   }
 
   @Override
-  public String next(Path path, MediaType type) {
+  public Optional<String> next(Path path, MediaType type) {
 
     if (path == null) {
-      return "null";
+      return Optional.empty();
     }
 
     String filename = FilenameUtils.removeExtension(path.toFile().getName());
-    return prefix ? MediaType.generateId(type, filename) : filename;
+    String id = prefix ? MediaType.generateId(type, filename) : filename;
+    return Optional.of(id);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/ObjectIdGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/ObjectIdGenerator.java
@@ -1,6 +1,7 @@
 package org.vitrivr.cineast.core.extraction.idgenerator;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import org.vitrivr.cineast.core.data.MediaType;
 
 /**
@@ -13,11 +14,11 @@ public interface ObjectIdGenerator {
   /**
    * Generates the next objectId and returns it as a string. That objectId should already contain the MediaType prefix, if the ID type supports media-type prefixing.
    * <p>
-   * Important: If the supply of ID's is depleted OR no ID could be generated for some reason, this method returns null!
+   * Important: If the supply of ID's is depleted OR no ID could be generated for some reason, this method returns {@link java.util.Optional#EMPTY}!
    *
    * @param path Path to the file for which an ID should be generated.
    * @param type MediaType of the file for which an ID should be generated.
-   * @return Next ID in the sequence or null
+   * @return Next ID in the sequence or nothing
    */
-  String next(Path path, MediaType type);
+  Optional<String> next(Path path, MediaType type);
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/SequentialObjectIdGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/SequentialObjectIdGenerator.java
@@ -2,6 +2,7 @@ package org.vitrivr.cineast.core.extraction.idgenerator;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import org.vitrivr.cineast.core.data.MediaType;
 
@@ -57,12 +58,12 @@ public class SequentialObjectIdGenerator implements ObjectIdGenerator {
 
   /**
    * Generates the next ID in the sequence.
-   *
-   * @param path Path to the file for which an ID should be generated.
+   *  @param path Path to the file for which an ID should be generated.
    * @param type MediaType of the file for which an ID should be generated.
+   * @return
    */
   @Override
-  public String next(Path path, MediaType type) {
-    return MediaType.generateId(type, String.format(this.format, this.counter.getAndIncrement()));
+  public Optional<String> next(Path path, MediaType type) {
+    return Optional.of(MediaType.generateId(type, String.format(this.format, this.counter.getAndIncrement())));
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/Sha1ObjectIdGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/Sha1ObjectIdGenerator.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,7 +16,7 @@ public class Sha1ObjectIdGenerator implements ObjectIdGenerator {
   private static final Logger LOGGER = LogManager.getLogger();
 
   @Override
-  public String next(Path path, MediaType type) {
+  public Optional<String> next(Path path, MediaType type) {
 
     String sha1 = "0000000000000000000000000000000000000000";
 
@@ -27,7 +28,7 @@ public class Sha1ObjectIdGenerator implements ObjectIdGenerator {
       LOGGER.error("Error while creating SHA1 id for object at '{}': {}", path, LogHelper.getStackTrace(e));
     }
 
-    return MediaType.generateId(type, sha1);
+    return Optional.of(MediaType.generateId(type, sha1));
 
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/UniqueObjectIdGenerator.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/idgenerator/UniqueObjectIdGenerator.java
@@ -3,6 +3,7 @@ package org.vitrivr.cineast.core.extraction.idgenerator;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.vitrivr.cineast.core.data.MediaType;
 
@@ -49,14 +50,15 @@ public class UniqueObjectIdGenerator implements ObjectIdGenerator {
    *
    * @param path Path to the file for which an ID should be generated.
    * @param type MediaType of the file for which an ID should be generated.
+   * @return
    */
   @Override
-  public String next(Path path, MediaType type) {
+  public Optional<String> next(Path path, MediaType type) {
     String rawId;
     do {
       rawId = RandomStringUtils.randomAlphanumeric(this.length);
     } while (this.usedIds.contains(rawId));
     this.usedIds.add(rawId);
-    return MediaType.generateId(type, rawId);
+    return Optional.of(MediaType.generateId(type, rawId));
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/extraction/segmenter/image/ImageSequenceSegmenter.java
@@ -1,13 +1,12 @@
 package org.vitrivr.cineast.core.extraction.segmenter.image;
 
+import com.google.common.collect.Sets;
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
-import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vitrivr.cineast.core.data.MediaType;
@@ -69,7 +68,7 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
     if (context.objectIdGenerator() instanceof FileNameObjectIdGenerator) {
       this.idgenerator = (FileNameObjectIdGenerator) context.objectIdGenerator();
     } else {
-      this.idgenerator = null;
+      throw new IllegalStateException("This segmenter is only intended to be used with id generation based on filenames");
     }
   }
 
@@ -118,7 +117,11 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
         if (next.second.isPresent()) {
           final ImageSegment segment = new ImageSegment(next.second.get(), this.factory);
           if (this.idgenerator != null) {
-            segment.setId(this.idgenerator.next(next.first, MediaType.IMAGE_SEQUENCE));
+            Optional<String> segId = this.idgenerator.next(next.first, MediaType.IMAGE_SEQUENCE);
+            if (segId.isEmpty()) {
+              throw new IllegalStateException("ObjectId generation based on path " + next.first + " returned empty");
+            }
+            segment.setId(segId.get());
           }
           this.segments.offer(segment);
         }
@@ -133,6 +136,7 @@ public class ImageSequenceSegmenter implements Segmenter<ImageSequence> {
 
   /**
    * Returns {@link MediaType#IMAGE_SEQUENCE}, as this {@link Segmenter} is for image sequences
+   *
    * @return
    */
   @Override


### PR DESCRIPTION
Motivated by my review #360, I refactored and cleaned up the existing object id generators.

- Using `Optional` instead of "null" as a string (!)
- Removed unused code
- Using `getOrDefault` instead of more verbose code
- Throwing exceptions instead of generating objects with `null` as id.