### PR TITLE
Improved error message when no config is available

### DIFF
--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
@@ -1,13 +1,13 @@
 package org.vitrivr.cineast.api;
 
+import static org.vitrivr.cineast.core.util.CineastConstants.DEFAULT_CONFIG_PATH;
+
 import org.vitrivr.cineast.standalone.cli.CineastCli;
 import org.vitrivr.cineast.standalone.config.Config;
 import org.vitrivr.cineast.standalone.monitoring.PrometheusServer;
 import org.vitrivr.cineast.standalone.util.CLI;
 
 public class Main {
-
-  public static final String DEFAULT_PATH = "cineast.json";
 
   /**
    * Entrypoint for Cineast API application.
@@ -17,9 +17,9 @@ public class Main {
   public static void main(String[] args) {
     /* (Force) load application config. */
     if (args.length == 0) {
-      System.out.println("No config path given, loading default config '" + DEFAULT_PATH + "'");
-      if (Config.loadConfig(DEFAULT_PATH) == null) {
-        System.err.println("Failed to load Cineast configuration from '" + DEFAULT_PATH + "'. Cineast API will shutdown...");
+      System.out.println("No config path given, loading default config '" + DEFAULT_CONFIG_PATH + "'");
+      if (Config.loadConfig(DEFAULT_CONFIG_PATH) == null) {
+        System.err.println("Failed to load Cineast configuration from '" + DEFAULT_CONFIG_PATH + "'. Cineast API will shutdown...");
         System.exit(1);
       }
     }

--- a/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
+++ b/cineast-api/src/main/java/org/vitrivr/cineast/api/Main.java
@@ -7,6 +7,8 @@ import org.vitrivr.cineast.standalone.util.CLI;
 
 public class Main {
 
+  public static final String DEFAULT_PATH = "cineast.json";
+
   /**
    * Entrypoint for Cineast API application.
    *
@@ -15,8 +17,11 @@ public class Main {
   public static void main(String[] args) {
     /* (Force) load application config. */
     if (args.length == 0) {
-      System.out.println("No config path given, loading default config cineast.json");
-      Config.loadConfig("cineast.json");
+      System.out.println("No config path given, loading default config '" + DEFAULT_PATH + "'");
+      if (Config.loadConfig(DEFAULT_PATH) == null) {
+        System.err.println("Failed to load Cineast configuration from '" + DEFAULT_PATH + "'. Cineast API will shutdown...");
+        System.exit(1);
+      }
     }
 
     /* (Force) load application config. */

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/util/CineastConstants.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/util/CineastConstants.java
@@ -32,4 +32,6 @@ public class CineastConstants {
   public static final String KEY_COL_NAME = "key";
   public static final String VAL_COL_NAME = "value";
 
+  public static final String DEFAULT_CONFIG_PATH = "cineast.json";
+
 }

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/Main.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/Main.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.standalone;
 
+import static org.vitrivr.cineast.core.util.CineastConstants.DEFAULT_CONFIG_PATH;
+
 import com.github.rvesse.airline.parser.ParseResult;
 import com.github.rvesse.airline.parser.errors.ParseException;
 import java.io.IOException;
@@ -18,11 +20,21 @@ public class Main {
    */
   public static void main(String[] args) {
     /* (Force) load application config. */
-    if (Config.loadConfig(args[0]) == null) {
-      System.err.println("Failed to load Cineast configuration from '" + args[0] + "'. Cineast will shutdown...");
-      System.exit(1);
+    if (args.length == 0) {
+      System.out.println("No config path given, loading default config '" + DEFAULT_CONFIG_PATH + "'");
+      if (Config.loadConfig(DEFAULT_CONFIG_PATH) == null) {
+        System.err.println("Failed to load Cineast configuration from '" + DEFAULT_CONFIG_PATH + "'. Cineast API will shutdown...");
+        System.exit(1);
+      }
     }
 
+    /* (Force) load application config. */
+    if (args.length != 0) {
+      if (Config.loadConfig(args[0]) == null) {
+        System.err.println("Failed to load Cineast configuration from '" + args[0] + "'. Cineast API will shutdown...");
+        System.exit(1);
+      }
+    }
     /* Initialize Monitoring */
     try {
       PrometheusServer.initialize();

--- a/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/Config.java
+++ b/cineast-runtime/src/main/java/org/vitrivr/cineast/standalone/config/Config.java
@@ -1,5 +1,7 @@
 package org.vitrivr.cineast.standalone.config;
 
+import static org.vitrivr.cineast.core.util.CineastConstants.DEFAULT_CONFIG_PATH;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.File;
@@ -38,7 +40,7 @@ public class Config {
    */
   public synchronized static Config sharedConfig() {
     if (sharedConfig == null) {
-      loadConfig("cineast.json");
+      loadConfig(DEFAULT_CONFIG_PATH);
     }
     return sharedConfig;
   }


### PR DESCRIPTION
Based on #363, if no config path is provided & no config file is available, the behavior is inconsistent in that Cineast does not shut down but proceeds.

This change makes sure the behavior is consistent