### PR TITLE
DBSelector Documentation Updates

### DIFF
--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/DBSelector.java
@@ -6,7 +6,6 @@ import static org.vitrivr.cineast.core.util.CineastConstants.KEY_COL_NAME;
 import com.google.common.collect.Lists;
 import java.io.Closeable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,121 +30,128 @@ public interface DBSelector extends Closeable {
 
   Logger LOGGER = LogManager.getLogger();
 
+  /**
+   * Tells this selector to use a specific entity. This is intended to be called once per selector after it is instantiated, calling it multiple times may cause issues depending on the underlying implementation.
+   */
   boolean open(String name);
 
+  /**
+   * Closes this selector and all associated resources. Calling any method afterwards may cause issues.
+   */
   void close();
 
   /**
    * Convenience-wrapper to query with float-arrays {@link #getNearestNeighboursGeneric(int, PrimitiveTypeProvider, String, Class, ReadableQueryConfig)}
    */
-  default <E extends DistanceElement> List<E> getNearestNeighboursGeneric(int k, float[] query, String column, Class<E> distanceElementClass, ReadableQueryConfig config) {
-    return getNearestNeighboursGeneric(k, new FloatArrayTypeProvider(query), column, distanceElementClass, config);
+  default <E extends DistanceElement> List<E> getNearestNeighboursGeneric(int k, float[] query, String column, Class<E> distanceElementClass, ReadableQueryConfig queryConfig) {
+    return getNearestNeighboursGeneric(k, new FloatArrayTypeProvider(query), column, distanceElementClass, queryConfig);
   }
 
   /**
-   * * Finds the {@code k}-nearest neighbours of the given {@code queryProvider} in {@code column} using the provided distance function in {@code config}. {@code ScoreElementClass} defines the specific type of {@link DistanceElement} to be created internally and returned by this method.
+   * * Finds the {@code k}-nearest neighbours of the given {@code queryProvider} in {@code column} using the provided distance function in {@code queryConfig}. {@code ScoreElementClass} defines the specific type of {@link DistanceElement} to be created internally and returned by this method.
    *
    * @param k                    maximum number of results
    * @param queryProvider        query vector
-   * @param column               feature column to do the search
-   * @param distanceElementClass class of the {@link DistanceElement} type
-   * @param config               query config
-   * @param <E>                  type of the {@link DistanceElement}
-   * @return a list of elements with their distance
+   * @param column               feature column to do the nns on
+   * @param distanceElementClass class of the {@link DistanceElement} type (e.g., {@link SegmentDistanceElement}
+   * @param <T>                  type of the {@link DistanceElement}
+   * @param queryConfig          query config
+   * @return a list of ids with their distance
    */
-  default <E extends DistanceElement> List<E> getNearestNeighboursGeneric(int k, PrimitiveTypeProvider queryProvider, String column, Class<E> distanceElementClass, ReadableQueryConfig config) {
+  default <T extends DistanceElement> List<T> getNearestNeighboursGeneric(int k, PrimitiveTypeProvider queryProvider, String column, Class<T> distanceElementClass, ReadableQueryConfig queryConfig) {
     if (queryProvider.getType().equals(ProviderDataType.FLOAT_ARRAY) || queryProvider.getType().equals(ProviderDataType.INT_ARRAY)) {
       //Default-implementation for backwards compatibility.
-      return getNearestNeighboursGeneric(k, PrimitiveTypeProvider.getSafeFloatArray(queryProvider), column, distanceElementClass, config);
+      return getNearestNeighboursGeneric(k, PrimitiveTypeProvider.getSafeFloatArray(queryProvider), column, distanceElementClass, queryConfig);
     }
     LogManager.getLogger().error("{} does not support other queries than float-arrays.", this.getClass().getSimpleName());
     throw new UnsupportedOperationException();
   }
 
-  default List<SegmentDistanceElement> getFarthestNeighboursGeneric(int k, PrimitiveTypeProvider queryProvider, String column, Class<SegmentDistanceElement> distanceElementClass, ReadableQueryConfig config) {
-    throw new UnsupportedOperationException("Farthest neighbors are not supported");
-  }
-
-
   /**
    * Performs a batched kNN-search with multiple query vectors. That is, the storage engine is tasked to perform the kNN search for each vector in the provided list and returns the union of the results for every query.
    *
-   * @param k                    The number k vectors to return per query.
-   * @param vectors              The list of vectors to use.
-   * @param column               The column to perform the kNN search on.
-   * @param distanceElementClass class of the {@link DistanceElement} type
-   * @param configs              The query configuration, which may contain distance definitions or query-hints.
+   * @param k                    maximum number of results
+   * @param vectors              list of query vectors
+   * @param column               feature column to do the nns on
+   * @param distanceElementClass class of the {@link DistanceElement} type (e.g., {@link SegmentDistanceElement}
    * @param <T>                  The type T of the resulting <T> type of the {@link DistanceElement}.
-   * @return List of results.
+   * @param queryConfigs         query configs
+   * @return a list of ids with their distance
    */
-  <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> configs);
+  <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> queryConfigs);
 
   /**
-   * In contrast to {@link #getNearestNeighboursGeneric(int, float[], String, Class, ReadableQueryConfig)}, this method returns all elements of a row
+   * In contrast to {@link #getNearestNeighboursGeneric(int, float[], String, Class, ReadableQueryConfig)}, this method returns all columns per result row
    */
-  List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig config);
+  List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig queryConfig);
 
   /**
-   * SELECT 'vectorname' from entity where 'fieldname' = 'value'
+   * SELECT 'vectorname' from entity where 'column' = 'value'
    */
-  List<float[]> getFeatureVectors(String fieldName, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig);
+  List<float[]> getFeatureVectors(String column, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig);
 
   /**
-   * for legacy support, takes the float[] method by default
+   * Conversion to PrimitiveTypeProviders is expensive so underlying classes should feel free to override if they wish to optimize for performance
+   * <p>
+   * takes the float[] method by default
    */
-  default List<PrimitiveTypeProvider> getFeatureVectorsGeneric(String fieldName, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig qc) {
-    return getFeatureVectors(fieldName, value, vectorName, qc).stream().map(FloatArrayTypeProvider::new).collect(Collectors.toList());
-  }
-
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, PrimitiveTypeProvider value) {
-    return getRows(fieldName, Collections.singleton(value));
-  }
-
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, PrimitiveTypeProvider... values) {
-    return getRows(fieldName, Arrays.asList(values));
+  default List<PrimitiveTypeProvider> getFeatureVectorsGeneric(String column, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig qc) {
+    return getFeatureVectors(column, value, vectorName, qc).stream().map(FloatArrayTypeProvider::new).collect(Collectors.toList());
   }
 
   /**
-   * SELECT * where fieldName IN (values)
+   * {@link #getRows(String, Iterable, String)}
    */
-  List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, Iterable<PrimitiveTypeProvider> values);
-
-  /**
-   * By default, the queryID is ignored
-   */
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, Iterable<PrimitiveTypeProvider> values, String dbQueryID) {
-    return getRows(fieldName, values);
+  default List<Map<String, PrimitiveTypeProvider>> getRows(String column, PrimitiveTypeProvider value) {
+    return getRows(column, Collections.singleton(value), null);
   }
 
   /**
-   * Conversion to PrimitiveTypeProviders is expensive so feel free to use & implement extension for generic objects
+   * {@link #getRows(String, Iterable, String)}
    */
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, List<String> values) {
-    return getRows(fieldName, values.stream().map(StringTypeProvider::new).collect(Collectors.toList()));
+  default List<Map<String, PrimitiveTypeProvider>> getRows(String column, Iterable<PrimitiveTypeProvider> values) {
+    return getRows(column, values, null);
   }
 
   /**
-   * Conversion to PrimitiveTypeProviders is expensive so feel free to use & implement extension for generic objects
+   * SELECT * where column IN (values)
    */
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, List<String> values, String dbQueryID) {
-    return getRows(fieldName, values.stream().map(StringTypeProvider::new).collect(Collectors.toList()));
+  List<Map<String, PrimitiveTypeProvider>> getRows(String column, Iterable<PrimitiveTypeProvider> values, String dbQueryID);
+
+  /**
+   * Conversion to PrimitiveTypeProviders is expensive so underlying classes should feel free to override if they wish to optimize for performance
+   * <p>
+   * {@link #getRows(String, Iterable, String)}
+   */
+  default List<Map<String, PrimitiveTypeProvider>> getRows(String column, List<String> values) {
+    return getRows(column, values.stream().map(StringTypeProvider::new).collect(Collectors.toList()), null);
+  }
+
+  /**
+   * Conversion to PrimitiveTypeProviders is expensive so underlying classes should feel free to override if they wish to optimize for performance
+   * <p>
+   * {@link #getRows(String, Iterable, String)}
+   */
+  default List<Map<String, PrimitiveTypeProvider>> getRows(String column, List<String> values, String dbQueryID) {
+    return getRows(column, values.stream().map(StringTypeProvider::new).collect(Collectors.toList()), null);
   }
 
   /**
    * Performs a fulltext search with multiple query terms. That is, the storage engine is tasked to lookup for entries in the provided fields that match the provided query terms.
    *
-   * @param rows      The number of rows that should be returned.
-   * @param fieldname The field that should be used for lookup.
-   * @param terms     The query terms. Individual terms will be connected by a logical OR.
+   * @param rows        The number of rows that should be returned.
+   * @param column      The field that should be used for lookup.
+   * @param queryConfig query config
+   * @param terms       The query terms. Individual terms will be connected by a logical OR.
    * @return List of rows that math the fulltext search.
    */
-  List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String fieldname, ReadableQueryConfig queryConfig, String... terms);
+  List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String column, ReadableQueryConfig queryConfig, String... terms);
 
   /**
-   * {@link #getRows(String, RelationalOperator, Iterable)}
+   * {@link #getRows(String, RelationalOperator, Iterable, ReadableQueryConfig)}
    */
-  default List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, RelationalOperator operator, PrimitiveTypeProvider value) {
-    return getRows(fieldName, operator, Collections.singleton(value));
+  default List<Map<String, PrimitiveTypeProvider>> getRows(String column, RelationalOperator operator, PrimitiveTypeProvider value, ReadableQueryConfig queryConfig) {
+    return getRows(column, operator, Collections.singleton(value), queryConfig);
   }
 
   /**
@@ -153,24 +159,26 @@ public interface DBSelector extends Closeable {
    * <p>
    * i.e. SELECT * from WHERE A <Operator> B
    *
-   * @param fieldName The name of the database field .
-   * @param operator  The {@link RelationalOperator} that should be used for comparison.
-   * @param values    The values the field should be compared to.
+   * @param column      The name of the database field .
+   * @param operator    The {@link RelationalOperator} that should be used for comparison.
+   * @param values      The values the field should be compared to.
+   * @param queryConfig query config
    * @return List of rows (one row is represented by one Map of the field ames and the data contained in the field).
    */
-  List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values);
+  List<Map<String, PrimitiveTypeProvider>> getRows(String column, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values, ReadableQueryConfig queryConfig);
 
   /**
    * Performs a boolean lookup based on multiple conditions, linked with AND. Each element of the list specifies one of the conditions - left middle right, i.e. id IN (1, 5, 7)
    *
-   * @param conditions conditions which will be linked by AND
-   * @param identifier column upon which the retain operation will be performed if the database layer does not support compound boolean retrieval.
-   * @param projection Which columns shall be selected
+   * @param conditions  conditions which will be linked by AND
+   * @param identifier  column upon which the retain operation will be performed if the database layer does not support compound boolean retrieval.
+   * @param projection  Which columns shall be selected
+   * @param queryConfig query config
    */
-  default List<Map<String, PrimitiveTypeProvider>> getRowsAND(List<Triple<String, RelationalOperator, List<PrimitiveTypeProvider>>> conditions, String identifier, List<String> projection, ReadableQueryConfig qc) {
+  default List<Map<String, PrimitiveTypeProvider>> getRowsAND(List<Triple<String, RelationalOperator, List<PrimitiveTypeProvider>>> conditions, String identifier, List<String> projection, ReadableQueryConfig queryConfig) {
     HashMap<String, Map<String, PrimitiveTypeProvider>> relevant = new HashMap<>();
     for (Triple<String, RelationalOperator, List<PrimitiveTypeProvider>> condition : conditions) {
-      List<Map<String, PrimitiveTypeProvider>> rows = this.getRows(condition.getLeft(), condition.getMiddle(), condition.getRight());
+      List<Map<String, PrimitiveTypeProvider>> rows = this.getRows(condition.getLeft(), condition.getMiddle(), condition.getRight(), queryConfig);
       if (rows.isEmpty()) {
         return Collections.emptyList();
       }
@@ -203,8 +211,7 @@ public interface DBSelector extends Closeable {
   }
 
   /**
-   * counts how many times each element appears per value in a given column.
-   * This can be useful for example to debug duplicates or count occurences of tags
+   * counts how many times each element appears per value in a given column. This can be useful for example to debug duplicates or count occurences of tags
    */
   default Map<String, Integer> countDistinctValues(String column) {
     Map<String, Integer> count = new HashMap<>();
@@ -215,21 +222,20 @@ public interface DBSelector extends Closeable {
   /**
    * Returns all available metadata based on the specification.
    */
-  default List<Map<String, PrimitiveTypeProvider>> getMetadataBySpec(List<MetadataAccessSpecification> spec, String dbQueryID) {
-    return this.getMetadataByIdAndSpec(null, spec, null, dbQueryID);
+  default List<Map<String, PrimitiveTypeProvider>> getMetadataBySpec(List<MetadataAccessSpecification> spec, String dbQueryID, ReadableQueryConfig queryConfig) {
+    return this.getMetadataByIdAndSpec(null, spec, null, dbQueryID, queryConfig);
   }
 
   /**
    * Retrieves Metadata based on ids, access specification and other parameters
    *
-   * @param ids ids for which to fetch metadata
-   * @param spec which metadata should be fetched
-   * @param idColName the name of the column which the id refers to. Can be null, in which case the default behavior is used
-   * @param dbQueryID query identifier. Can be null
-   *
-   * Horribly slow default implementation which iterates over the whole table
+   * @param ids         ids for which to fetch metadata
+   * @param spec        which metadata should be fetched
+   * @param idColName   the name of the column which the id refers to. Can be null, in which case the default behavior is used
+   * @param dbQueryID   query identifier. Can be null
+   * @param queryConfig query config
    */
-  default List<Map<String, PrimitiveTypeProvider>> getMetadataByIdAndSpec(List<String> ids, List<MetadataAccessSpecification> spec, String idColName, String dbQueryID) {
+  default List<Map<String, PrimitiveTypeProvider>> getMetadataByIdAndSpec(List<String> ids, List<MetadataAccessSpecification> spec, String idColName, String dbQueryID, ReadableQueryConfig queryConfig) {
     LOGGER.trace("fetching metadata with spec, dbQueryID {}", dbQueryID);
     return getAll().stream().filter(tuple -> {
       // check if there are any elements of the specification which do not work

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/ImporterSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/ImporterSelector.java
@@ -5,6 +5,7 @@ import static org.vitrivr.cineast.core.util.CineastConstants.GENERIC_ID_COLUMN_Q
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,12 +55,12 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
   }
 
   @Override
-  public <E extends DistanceElement> List<E> getNearestNeighboursGeneric(int k, PrimitiveTypeProvider queryProvider, String column, Class<E> distanceElementClass, ReadableQueryConfig config) {
+  public <E extends DistanceElement> List<E> getNearestNeighboursGeneric(int k, PrimitiveTypeProvider queryProvider, String column, Class<E> distanceElementClass, ReadableQueryConfig queryConfig) {
     List<Map<String, PrimitiveTypeProvider>> results;
     if (queryProvider.getType().equals(ProviderDataType.FLOAT_ARRAY) || queryProvider.getType().equals(ProviderDataType.INT_ARRAY)) {
-      results = getNearestNeighbourRows(k, queryProvider.getFloatArray(), column, config);
+      results = getNearestNeighbourRows(k, queryProvider.getFloatArray(), column, queryConfig);
     } else {
-      results = getNearestNeighbourRows(k, queryProvider, column, config);
+      results = getNearestNeighbourRows(k, queryProvider, column, queryConfig);
     }
     return results.stream().map(m -> DistanceElement.create(distanceElementClass, m.get(GENERIC_ID_COLUMN_QUALIFIER).getString(), m.get(DB_DISTANCE_VALUE_QUALIFIER).getDouble())).limit(k).collect(Collectors.toList());
   }
@@ -114,19 +115,19 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
 
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig config) {
+  public List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig queryConfig) {
 
-    config = QueryConfig.clone(config);
+    queryConfig = QueryConfig.clone(queryConfig);
 
     Importer<?> importer = newImporter(this.file);
 
-    FloatArrayDistance distance = FloatArrayDistance.fromQueryConfig(config);
+    FloatArrayDistance distance = FloatArrayDistance.fromQueryConfig(queryConfig);
 
     FixedSizePriorityQueue<Map<String, PrimitiveTypeProvider>> knn = FixedSizePriorityQueue.create(k, new PrimitiveTypeMapDistanceComparator(column, vector, distance));
 
     HashSet<String> relevant = null;
-    if (config.hasRelevantSegmentIds()) {
-      Set<String> ids = config.getRelevantSegmentIds();
+    if (queryConfig.hasRelevantSegmentIds()) {
+      Set<String> ids = queryConfig.getRelevantSegmentIds();
       relevant = new HashSet<>(ids.size());
       relevant.addAll(ids);
     }
@@ -158,7 +159,7 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
   }
 
   @Override
-  public List<float[]> getFeatureVectors(String fieldName, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig) {
+  public List<float[]> getFeatureVectors(String column, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig) {
     ArrayList<float[]> _return = new ArrayList<>(1);
 
     if (value == null || value.getString().isEmpty()) {
@@ -168,13 +169,13 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
     Importer<?> importer = newImporter(this.file);
     Map<String, PrimitiveTypeProvider> map;
     while ((map = importer.readNextAsMap()) != null) {
-      if (!map.containsKey(fieldName)) {
+      if (!map.containsKey(column)) {
         continue;
       }
       if (!map.containsKey(vectorName)) {
         continue;
       }
-      if (value.equals(map.get(fieldName).getString())) {
+      if (value.equals(map.get(column).getString())) {
         _return.add(PrimitiveTypeProvider.getSafeFloatArray(map.get(vectorName)));
       }
     }
@@ -183,33 +184,7 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, PrimitiveTypeProvider... values) {
-    ArrayList<Map<String, PrimitiveTypeProvider>> _return = new ArrayList<>(1);
-
-    if (values == null || values.length == 0) {
-      return _return;
-    }
-
-    Importer<?> importer = newImporter(this.file);
-    Map<String, PrimitiveTypeProvider> map;
-    while ((map = importer.readNextAsMap()) != null) {
-      if (!map.containsKey(fieldName)) {
-        continue;
-      }
-      for (int i = 0; i < values.length; ++i) {
-        if (values[i].equals(map.get(fieldName).getString())) {
-          _return.add(map);
-          break;
-        }
-      }
-
-    }
-
-    return _return;
-  }
-
-  @Override
-  public List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, Iterable<PrimitiveTypeProvider> values) {
+  public List<Map<String, PrimitiveTypeProvider>> getRows(String column, Iterable<PrimitiveTypeProvider> values, String dbQueryID) {
     if (values == null) {
       return new ArrayList<>(0);
     }
@@ -222,7 +197,7 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
     PrimitiveTypeProvider[] valueArr = new PrimitiveTypeProvider[tmp.size()];
     tmp.toArray(valueArr);
 
-    return this.getRows(fieldName, valueArr);
+    return this.getRows(column, Arrays.asList(valueArr));
   }
 
   @Override
@@ -249,17 +224,17 @@ public abstract class ImporterSelector<T extends Importer<?>> implements DBSelec
   protected abstract String getFileExtension();
 
   @Override
-  public <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> configs) {
+  public <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> queryConfigs) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values) {
+  public List<Map<String, PrimitiveTypeProvider>> getRows(String column, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values, ReadableQueryConfig queryConfig) {
     throw new IllegalStateException("Not implemented.");
   }
 
-  public List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String fieldname, ReadableQueryConfig queryConfig, String... terms) {
+  public List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String column, ReadableQueryConfig queryConfig, String... terms) {
     throw new IllegalStateException("Not implemented.");
   }
 

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/NoDBSelector.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/NoDBSelector.java
@@ -22,27 +22,27 @@ public class NoDBSelector implements DBSelector {
   }
 
   @Override
-  public <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> configs) {
+  public <T extends DistanceElement> List<T> getBatchedNearestNeighbours(int k, List<float[]> vectors, String column, Class<T> distanceElementClass, List<ReadableQueryConfig> queryConfigs) {
     return new ArrayList<>(0);
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig config) {
+  public List<Map<String, PrimitiveTypeProvider>> getNearestNeighbourRows(int k, float[] vector, String column, ReadableQueryConfig queryConfig) {
     return new ArrayList<>(0);
   }
 
   @Override
-  public List<float[]> getFeatureVectors(String fieldName, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig) {
+  public List<float[]> getFeatureVectors(String column, PrimitiveTypeProvider value, String vectorName, ReadableQueryConfig queryConfig) {
     return new ArrayList<>(0);
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String fieldname, ReadableQueryConfig queryConfig, String... terms) {
+  public List<Map<String, PrimitiveTypeProvider>> getFulltextRows(int rows, String column, ReadableQueryConfig queryConfig, String... terms) {
     return new ArrayList<>(0);
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, Iterable<PrimitiveTypeProvider> values) {
+  public List<Map<String, PrimitiveTypeProvider>> getRows(String column, Iterable<PrimitiveTypeProvider> values, String dbQueryID) {
     return new ArrayList<>(0);
   }
 
@@ -62,7 +62,7 @@ public class NoDBSelector implements DBSelector {
   }
 
   @Override
-  public List<Map<String, PrimitiveTypeProvider>> getRows(String fieldName, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values) {
+  public List<Map<String, PrimitiveTypeProvider>> getRows(String column, RelationalOperator operator, Iterable<PrimitiveTypeProvider> values, ReadableQueryConfig queryConfig) {
     return new ArrayList<>(0);
   }
 }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/db/dao/reader/AbstractMetadataReader.java
@@ -81,7 +81,7 @@ public abstract class AbstractMetadataReader<R> extends AbstractEntityReader {
     ids = sanitizeIds(ids);
     spec = sanitizeSpec(spec);
     String dbQueryID = DBQueryIDGenerator.generateQueryID("find-md-spec-" + tableName, queryID);
-    List<Map<String, PrimitiveTypeProvider>> results = selector.getMetadataByIdAndSpec(ids, spec, idColName, dbQueryID);
+    List<Map<String, PrimitiveTypeProvider>> results = selector.getMetadataByIdAndSpec(ids, spec, idColName, dbQueryID, null);
     LOGGER.debug("Performed metadata lookup for {} ids in {} ms. {} results.", ids.size(), watch.getTime(TimeUnit.MILLISECONDS), results.size());
     return mapToResultList(results);
   }
@@ -102,7 +102,7 @@ public abstract class AbstractMetadataReader<R> extends AbstractEntityReader {
     StopWatch watch = StopWatch.createStarted();
     spec = sanitizeSpec(spec);
     String dbQueryID = DBQueryIDGenerator.generateQueryID("find-my-spec-" + tableName, queryID);
-    List<Map<String, PrimitiveTypeProvider>> results = selector.getMetadataBySpec(spec, dbQueryID);
+    List<Map<String, PrimitiveTypeProvider>> results = selector.getMetadataBySpec(spec, dbQueryID, null);
     LOGGER.debug("Performed metadata lookup in {} ms. {} results.", watch.getTime(TimeUnit.MILLISECONDS), results.size());
     return mapToResultList(results);
   }

--- a/cineast-core/src/main/java/org/vitrivr/cineast/core/features/RangeBooleanRetriever.java
+++ b/cineast-core/src/main/java/org/vitrivr/cineast/core/features/RangeBooleanRetriever.java
@@ -25,9 +25,6 @@ public class RangeBooleanRetriever extends BooleanRetriever {
               RelationalOperator.LESS,
               RelationalOperator.IN));
 
-  private final HashMap<String, PrimitiveTypeProvider> minimumMap = new HashMap<>();
-  private final HashMap<String, PrimitiveTypeProvider> maximumMap = new HashMap<>();
-
   protected RangeBooleanRetriever(String entity, Collection<String> attributes) {
     super(entity, attributes);
   }
@@ -40,43 +37,5 @@ public class RangeBooleanRetriever extends BooleanRetriever {
   protected Collection<RelationalOperator> getSupportedOperators() {
     return SUPPORTED_OPERATORS;
   }
-
-  public PrimitiveTypeProvider getMinimum(String column) {
-    if (this.attributes.contains(column) && !this.minimumMap.containsKey(column)) {
-      populateExtremaMap();
-    }
-    return minimumMap.get(column);
-  }
-
-  public PrimitiveTypeProvider getMaximum(String column) {
-    if (this.attributes.contains(column) && !this.maximumMap.containsKey(column)) {
-      populateExtremaMap();
-    }
-    return maximumMap.get(column);
-  }
-
-  private void populateExtremaMap() {
-
-    PrimitiveProviderComparator comparator = new PrimitiveProviderComparator();
-
-    for (String column : this.attributes) {
-      List<PrimitiveTypeProvider> col = this.selector.getAll(column);
-      if (col.isEmpty()) {
-        continue;
-      }
-      PrimitiveTypeProvider min = col.get(0), max = col.get(0);
-      for (PrimitiveTypeProvider t : col) {
-        if (comparator.compare(t, min) < 0) {
-          min = t;
-        }
-        if (comparator.compare(t, max) > 0) {
-          max = t;
-        }
-      }
-      this.minimumMap.put(column, min);
-      this.maximumMap.put(column, max);
-    }
-  }
-
 
 }

--- a/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
+++ b/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -149,7 +150,7 @@ public abstract class DBBooleanIntegrationTest<R> {
   public void count() {
     selector.open(testTableName);
     Assertions.assertEquals(TABLE_CARD, selector.getAll().size());
-    Assertions.assertEquals(TABLE_CARD, selector.getAll(DATA_COL_NAME_1).size());
+    Assertions.assertEquals(TABLE_CARD, selector.getAll(Collections.singletonList(DATA_COL_NAME_1), -1).size());
   }
 
   @Test

--- a/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
+++ b/cineast-core/src/test/java/org/vitrivr/cineast/core/db/DBBooleanIntegrationTest.java
@@ -196,7 +196,7 @@ public abstract class DBBooleanIntegrationTest<R> {
     final List<PrimitiveTypeProvider> values = new ArrayList<>();
     values.add(PrimitiveTypeProvider.fromObject(-idToCheck));
     values.add(PrimitiveTypeProvider.fromObject(-(idToCheck - 1)));
-    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(DATA_COL_NAME_2, RelationalOperator.BETWEEN, values);
+    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(DATA_COL_NAME_2, RelationalOperator.BETWEEN, values, null);
     var list = result.stream().map(el -> el.get(ID_COL_NAME).getString()).collect(Collectors.toList());
     Assertions.assertTrue(hasItem(list, String.valueOf(idToCheck)));
     Assertions.assertTrue(hasItem(list, String.valueOf(idToCheck - 1)));
@@ -212,7 +212,7 @@ public abstract class DBBooleanIntegrationTest<R> {
     }
     final List<PrimitiveTypeProvider> values = new ArrayList<>();
     values.add(PrimitiveTypeProvider.fromObject(idToCheck));
-    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(ID_COL_NAME, RelationalOperator.GREATER, values);
+    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(ID_COL_NAME, RelationalOperator.GREATER, values, null);
     var list = result.stream().map(el -> el.get(ID_COL_NAME).getString()).collect(Collectors.toList());
     Assertions.assertTrue(hasItem(list, String.valueOf(TABLE_CARD - 1)));
   }
@@ -224,7 +224,7 @@ public abstract class DBBooleanIntegrationTest<R> {
     int idToCheck = 1;
     final List<PrimitiveTypeProvider> values = new ArrayList<>();
     values.add(PrimitiveTypeProvider.fromObject(idToCheck));
-    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(ID_COL_NAME, RelationalOperator.LESS, values);
+    final List<Map<String, PrimitiveTypeProvider>> result = selector.getRows(ID_COL_NAME, RelationalOperator.LESS, values, null);
     var list = result.stream().map(el -> el.get(ID_COL_NAME).getString()).collect(Collectors.toList());
     Assertions.assertTrue(hasItem(list, String.valueOf(0)));
   }


### PR DESCRIPTION
This PR unifies variable names & cleans up documentation in the `DBSelector` in preparation on upcoming work for multi-collection support.

Specifically, it adds query-configs to most retrieval methods where they were not already present, adds SQL-Like documentation to methods, cleans up unused code, makes clear which methods are convenience methods and which can be overriden by underlying implementations for performance-gains.